### PR TITLE
fix(mcp): address 7 security findings from static analysis (#13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "sync-manager": "bun src/sync/sync-manager.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.1"
+    "@modelcontextprotocol/sdk": "^1.25.1",
+    "zod": "^4.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/mcp/__tests__/audit-logger.test.ts
+++ b/src/mcp/__tests__/audit-logger.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for MCP audit logger.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { auditLog } from "../audit-logger";
+
+describe("auditLog", () => {
+  let stderrOutput: string[];
+  const originalWrite = process.stderr.write;
+
+  beforeEach(() => {
+    stderrOutput = [];
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrOutput.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalWrite;
+  });
+
+  test("writes structured JSON to stderr", () => {
+    auditLog("mem_search", { q: "test" }, 42, true);
+
+    expect(stderrOutput).toHaveLength(1);
+    const entry = JSON.parse(stderrOutput[0].replace("[audit] ", ""));
+    expect(entry.tool).toBe("mem_search");
+    expect(entry.args_keys).toEqual(["q"]);
+    expect(entry.duration_ms).toBe(42);
+    expect(entry.success).toBe(true);
+    expect(entry.error).toBeUndefined();
+  });
+
+  test("includes error when provided", () => {
+    auditLog("mem_search", {}, 10, false, "Something broke");
+
+    const entry = JSON.parse(stderrOutput[0].replace("[audit] ", ""));
+    expect(entry.success).toBe(false);
+    expect(entry.error).toBe("Something broke");
+  });
+
+  test("truncates long error messages", () => {
+    const longError = "x".repeat(300);
+    auditLog("mem_search", {}, 10, false, longError);
+
+    const entry = JSON.parse(stderrOutput[0].replace("[audit] ", ""));
+    expect(entry.error.length).toBeLessThan(210);
+    expect(entry.error).toContain("...");
+  });
+
+  test("logs only key names, not values", () => {
+    auditLog("mem_ingest", { content: "secret data", title: "hi" }, 5, true);
+
+    const raw = stderrOutput[0];
+    expect(raw).not.toContain("secret data");
+    const entry = JSON.parse(raw.replace("[audit] ", ""));
+    expect(entry.args_keys).toEqual(["content", "title"]);
+  });
+
+  test("includes ISO timestamp", () => {
+    auditLog("mem_status", {}, 1, true);
+
+    const entry = JSON.parse(stderrOutput[0].replace("[audit] ", ""));
+    expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/src/mcp/__tests__/validation.test.ts
+++ b/src/mcp/__tests__/validation.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for MCP tool input validation schemas.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { validateToolInput } from "../validation";
+
+describe("validateToolInput", () => {
+  describe("mem_status", () => {
+    test("accepts empty args", () => {
+      expect(() => validateToolInput("mem_status", {})).not.toThrow();
+    });
+  });
+
+  describe("mem_semantic_search", () => {
+    test("accepts valid input", () => {
+      const result = validateToolInput("mem_semantic_search", {
+        q: "test query",
+        limit: 10,
+        mode: "hybrid",
+      });
+      expect(result.q).toBe("test query");
+    });
+
+    test("rejects empty query", () => {
+      expect(() => validateToolInput("mem_semantic_search", { q: "" })).toThrow(
+        "Invalid input",
+      );
+    });
+
+    test("rejects missing query", () => {
+      expect(() => validateToolInput("mem_semantic_search", {})).toThrow(
+        "Invalid input",
+      );
+    });
+
+    test("coerces string limit to number", () => {
+      const result = validateToolInput("mem_semantic_search", {
+        q: "test",
+        limit: "5",
+      });
+      expect(result.limit).toBe(5);
+    });
+
+    test("rejects limit > 50", () => {
+      expect(() =>
+        validateToolInput("mem_semantic_search", { q: "test", limit: 100 }),
+      ).toThrow("Invalid input");
+    });
+
+    test("rejects invalid mode", () => {
+      expect(() =>
+        validateToolInput("mem_semantic_search", {
+          q: "test",
+          mode: "invalid",
+        }),
+      ).toThrow("Invalid input");
+    });
+
+    test("validates dateStart format", () => {
+      expect(() =>
+        validateToolInput("mem_semantic_search", {
+          q: "test",
+          dateStart: "not-a-date",
+        }),
+      ).toThrow("YYYY-MM-DD");
+    });
+
+    test("accepts valid dateStart", () => {
+      const result = validateToolInput("mem_semantic_search", {
+        q: "test",
+        dateStart: "2026-01-15",
+      });
+      expect(result.dateStart).toBe("2026-01-15");
+    });
+
+    test("validates tz format", () => {
+      expect(() =>
+        validateToolInput("mem_semantic_search", {
+          q: "test",
+          tz: "Bangkok",
+        }),
+      ).toThrow("timezone offset");
+    });
+
+    test("accepts valid tz offsets", () => {
+      expect(
+        validateToolInput("mem_semantic_search", { q: "test", tz: "+07:00" }),
+      ).toBeDefined();
+      expect(
+        validateToolInput("mem_semantic_search", { q: "test", tz: "-05:00" }),
+      ).toBeDefined();
+      expect(
+        validateToolInput("mem_semantic_search", { q: "test", tz: "Z" }),
+      ).toBeDefined();
+    });
+  });
+
+  describe("mem_semantic_get", () => {
+    test("accepts valid id", () => {
+      const result = validateToolInput("mem_semantic_get", { id: 42 });
+      expect(result.id).toBe(42);
+    });
+
+    test("coerces string id", () => {
+      const result = validateToolInput("mem_semantic_get", { id: "42" });
+      expect(result.id).toBe(42);
+    });
+
+    test("rejects id < 1", () => {
+      expect(() => validateToolInput("mem_semantic_get", { id: 0 })).toThrow(
+        "Invalid input",
+      );
+    });
+  });
+
+  describe("mem_get_observations", () => {
+    test("accepts valid ids array", () => {
+      const result = validateToolInput("mem_get_observations", {
+        ids: [1, 2, 3],
+      });
+      expect(result.ids).toEqual([1, 2, 3]);
+    });
+
+    test("rejects empty ids", () => {
+      expect(() =>
+        validateToolInput("mem_get_observations", { ids: [] }),
+      ).toThrow("Invalid input");
+    });
+
+    test("rejects > 200 ids", () => {
+      const ids = Array.from({ length: 201 }, (_, i) => i + 1);
+      expect(() => validateToolInput("mem_get_observations", { ids })).toThrow(
+        "Invalid input",
+      );
+    });
+  });
+
+  describe("mem_timeline", () => {
+    test("accepts anchor", () => {
+      const result = validateToolInput("mem_timeline", { anchor: 5 });
+      expect(result.anchor).toBe(5);
+    });
+
+    test("accepts query", () => {
+      const result = validateToolInput("mem_timeline", {
+        query: "some query",
+      });
+      expect(result.query).toBe("some query");
+    });
+
+    test("rejects when neither anchor nor query provided", () => {
+      expect(() => validateToolInput("mem_timeline", {})).toThrow(
+        "Either anchor or query must be provided",
+      );
+    });
+  });
+
+  describe("mem_entity_lookup", () => {
+    test("accepts valid name", () => {
+      const result = validateToolInput("mem_entity_lookup", {
+        name: "bugfix",
+      });
+      expect(result.name).toBe("bugfix");
+    });
+
+    test("rejects empty name", () => {
+      expect(() =>
+        validateToolInput("mem_entity_lookup", { name: "" }),
+      ).toThrow("Invalid input");
+    });
+  });
+
+  describe("mem_triplets_query", () => {
+    test("accepts valid predicate", () => {
+      const result = validateToolInput("mem_triplets_query", {
+        predicate: "is_type",
+      });
+      expect(result.predicate).toBe("is_type");
+    });
+
+    test("rejects invalid predicate", () => {
+      expect(() =>
+        validateToolInput("mem_triplets_query", { predicate: "unknown" }),
+      ).toThrow("Invalid input");
+    });
+  });
+
+  describe("mem_ingest", () => {
+    test("accepts single item", () => {
+      const result = validateToolInput("mem_ingest", {
+        provider: "cursor",
+        item: { title: "Test observation", content: "Some content" },
+      });
+      expect(result.provider).toBe("cursor");
+    });
+
+    test("accepts batch items", () => {
+      const result = validateToolInput("mem_ingest", {
+        items: [{ title: "Item 1" }, { title: "Item 2", content: "Content 2" }],
+      });
+      expect(result.provider).toBe("generic"); // default
+    });
+
+    test("rejects when neither item nor items provided", () => {
+      expect(() =>
+        validateToolInput("mem_ingest", { provider: "generic" }),
+      ).toThrow("Either item or items must be provided");
+    });
+
+    test("rejects batch > 100 items", () => {
+      const items = Array.from({ length: 101 }, (_, i) => ({
+        title: `Item ${i}`,
+      }));
+      expect(() => validateToolInput("mem_ingest", { items })).toThrow(
+        "Invalid input",
+      );
+    });
+
+    test("rejects item without title", () => {
+      expect(() =>
+        validateToolInput("mem_ingest", {
+          item: { content: "no title" },
+        }),
+      ).toThrow("Invalid input");
+    });
+  });
+
+  describe("mem_workflow_suggest", () => {
+    test("accepts empty args", () => {
+      const result = validateToolInput("mem_workflow_suggest", {});
+      expect(result.limit).toBe(5); // default
+    });
+
+    test("accepts query", () => {
+      const result = validateToolInput("mem_workflow_suggest", {
+        query: "deploy",
+      });
+      expect(result.query).toBe("deploy");
+    });
+  });
+
+  describe("unknown tool", () => {
+    test("passes through args for unknown tool", () => {
+      const args = { foo: "bar" };
+      expect(validateToolInput("unknown_tool", args)).toBe(args);
+    });
+  });
+});

--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -4,31 +4,31 @@
  * Centralized API communication with the remote server.
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { homedir } from 'os';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
-import type { ToolResponse } from './types';
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import type { ToolResponse } from "./types";
 
 // Get plugin root directory
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PLUGIN_ROOT = join(__dirname, '../..');
+const PLUGIN_ROOT = join(__dirname, "../..");
 
 // Canonical config location
-const CANONICAL_CONFIG = join(homedir(), '.memforge', 'config.json');
-const LEGACY_CONFIG = join(PLUGIN_ROOT, 'config.local.json');
+const CANONICAL_CONFIG = join(homedir(), ".memforge", "config.json");
+const LEGACY_CONFIG = join(PLUGIN_ROOT, "config.local.json");
 
 // API Configuration
-const DEFAULT_REMOTE_URL = 'https://memclaude.thaicloud.ai';
+const DEFAULT_REMOTE_URL = "https://memclaude.thaicloud.ai";
 const REMOTE_TIMEOUT_MS = 30000; // 30 seconds - vector search needs ~2-3s for embedding + similarity
 const SEARCH_TIMEOUT_MS = 60000; // 60 seconds for search operations (embedding generation can be slow)
 
 // API Key and URL loading
-let remoteApiKey = process.env.CLAUDE_MEM_API_KEY || '';
+let remoteApiKey = process.env.CLAUDE_MEM_API_KEY || "";
 let remoteApiUrl = process.env.CLAUDE_MEM_REMOTE_URL || DEFAULT_REMOTE_URL;
 
 // Role-based access control
-let pluginRole: 'client' | 'admin' = 'client';
+let pluginRole: "client" | "admin" = "client";
 
 // Track which config was loaded for diagnostics
 let configSource: string | null = null;
@@ -39,7 +39,7 @@ interface PluginConfig {
   serverUrl?: string;
   syncEnabled?: boolean;
   pollInterval?: number;
-  role?: 'client' | 'admin';
+  role?: "client" | "admin";
 }
 
 /**
@@ -63,7 +63,7 @@ function loadPluginConfig(): PluginConfig | null {
 
   try {
     configSource = configPath;
-    return JSON.parse(readFileSync(configPath, 'utf-8'));
+    return JSON.parse(readFileSync(configPath, "utf-8"));
   } catch {
     return null;
   }
@@ -76,7 +76,14 @@ export function initializeApiKey(): void {
   if (pluginConfig?.apiKey) {
     remoteApiKey = pluginConfig.apiKey;
     if (pluginConfig.serverUrl) {
-      remoteApiUrl = pluginConfig.serverUrl;
+      if (validateServerUrl(pluginConfig.serverUrl)) {
+        remoteApiUrl = pluginConfig.serverUrl;
+      } else {
+        process.stderr.write(
+          `[memforge] WARNING: serverUrl rejected by allowlist, using default: ${DEFAULT_REMOTE_URL}\n`,
+        );
+        remoteApiUrl = DEFAULT_REMOTE_URL;
+      }
     }
     if (pluginConfig.role) {
       pluginRole = pluginConfig.role;
@@ -89,9 +96,8 @@ export function initializeApiKey(): void {
   if (!remoteApiKey) {
     try {
       const settingsPath = `${process.env.HOME}/.claude-mem/settings.json`;
-      const fs = require('fs');
-      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-      remoteApiKey = settings.CLAUDE_MEM_API_KEY || '';
+      const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      remoteApiKey = settings.CLAUDE_MEM_API_KEY || "";
       configSource = settingsPath;
     } catch {
       // Settings not found, remote will be disabled
@@ -100,7 +106,7 @@ export function initializeApiKey(): void {
 }
 
 /** Get current plugin role */
-export function getRole(): 'client' | 'admin' {
+export function getRole(): "client" | "admin" {
   return pluginRole;
 }
 
@@ -124,15 +130,97 @@ export function getApiKey(): string {
   return remoteApiKey;
 }
 
+/** Allowed server hostnames for SSRF protection */
+const ALLOWED_HOSTS = ["memclaude.thaicloud.ai"];
+
+/**
+ * Validate a server URL against the allowlist.
+ * Allows: HTTPS to allowed hosts, or localhost/127.0.0.1 for dev.
+ * Set MEMFORGE_ALLOW_CUSTOM_URL=1 to bypass for self-hosted deployments.
+ */
+function validateServerUrl(url: string): boolean {
+  if (process.env.MEMFORGE_ALLOW_CUSTOM_URL === "1") return true;
+
+  try {
+    const parsed = new URL(url);
+
+    // Allow localhost for development (HTTP and HTTPS)
+    if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    }
+
+    // Require HTTPS for remote hosts
+    if (parsed.protocol !== "https:") return false;
+
+    // Block private/internal IP ranges
+    const ip = parsed.hostname;
+    if (
+      /^10\./.test(ip) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(ip) ||
+      /^192\.168\./.test(ip) ||
+      /^169\.254\./.test(ip) ||
+      ip === "::1" ||
+      /^fc00/i.test(ip) ||
+      /^fd/i.test(ip)
+    ) {
+      return false;
+    }
+
+    // Check against allowlist
+    return ALLOWED_HOSTS.includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
 /** Endpoint mapping from local to remote */
 const ENDPOINT_MAP: Record<string, string> = {
-  '/hybrid': '/api/search/hybrid',
-  '/vector': '/api/search/vector',
-  '/search': '/api/search',
-  '/timeline': '/api/timeline',
-  '/recent': '/api/observations',
-  '/observation': '/api/observations/batch',
+  "/hybrid": "/api/search/hybrid",
+  "/vector": "/api/search/vector",
+  "/search": "/api/search",
+  "/timeline": "/api/timeline",
+  "/recent": "/api/observations",
+  "/observation": "/api/observations/batch",
 };
+
+/** Allowed direct API paths (not in ENDPOINT_MAP) */
+const ALLOWED_API_PATHS = new Set([
+  "/api/timeline",
+  "/api/workflows",
+  "/api/ingest",
+  "/api/entity",
+  "/api/triplets",
+  "/api/stats",
+  "/api/observations",
+  "/api/observations/batch",
+  "/api/search",
+  "/api/search/hybrid",
+  "/api/search/vector",
+  "/health",
+]);
+
+/**
+ * Resolve endpoint with strict allowlist.
+ * Rejects unknown endpoints to prevent URL injection.
+ */
+function resolveEndpoint(endpoint: string): string {
+  // Check mapped endpoints first
+  const mapped = ENDPOINT_MAP[endpoint];
+  if (mapped) return mapped;
+
+  // Check direct API paths
+  if (ALLOWED_API_PATHS.has(endpoint)) return endpoint;
+
+  // Normalize to prevent path traversal (e.g., /api/entity/../secret)
+  const normalized = new URL(endpoint, "http://dummy").pathname;
+
+  // Check prefix match for parameterized paths (e.g., /api/entity/foo)
+  for (const allowed of ALLOWED_API_PATHS) {
+    if (normalized.startsWith(allowed + "/")) return normalized;
+  }
+
+  throw new Error(`Unknown endpoint: ${endpoint}`);
+}
 
 /**
  * Call Remote API with timeout.
@@ -144,15 +232,16 @@ const ENDPOINT_MAP: Record<string, string> = {
  */
 export async function callRemoteAPI(
   endpoint: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
 ): Promise<unknown> {
   if (!isRemoteEnabled()) {
-    throw new Error('Remote search not configured');
+    throw new Error("Remote search not configured");
   }
 
   // Use longer timeout for search endpoints (embedding generation is slow)
-  const isSearchEndpoint = ['/hybrid', '/vector', '/search'].includes(endpoint) ||
-    endpoint.includes('/search');
+  const isSearchEndpoint =
+    ["/hybrid", "/vector", "/search"].includes(endpoint) ||
+    endpoint.includes("/search");
   const timeout = isSearchEndpoint ? SEARCH_TIMEOUT_MS : REMOTE_TIMEOUT_MS;
 
   const controller = new AbortController();
@@ -166,11 +255,11 @@ export async function callRemoteAPI(
       }
     }
 
-    const remoteEndpoint = ENDPOINT_MAP[endpoint] || endpoint;
+    const remoteEndpoint = resolveEndpoint(endpoint);
     const url = `${remoteApiUrl}${remoteEndpoint}?${searchParams}`;
 
     const response = await fetch(url, {
-      headers: { 'X-API-Key': remoteApiKey },
+      headers: { "X-API-Key": remoteApiKey },
       signal: controller.signal,
     });
 
@@ -193,28 +282,31 @@ export async function callRemoteAPI(
  */
 export async function postRemoteAPI(
   endpoint: string,
-  body: Record<string, unknown>
+  body: Record<string, unknown>,
 ): Promise<unknown> {
   if (!isRemoteEnabled()) {
-    throw new Error('Remote search not configured');
+    throw new Error("Remote search not configured");
   }
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REMOTE_TIMEOUT_MS);
 
   try {
-    const response = await fetch(`${remoteApiUrl}${endpoint}`, {
-      method: 'POST',
+    const resolvedEndpoint = resolveEndpoint(endpoint);
+    const response = await fetch(`${remoteApiUrl}${resolvedEndpoint}`, {
+      method: "POST",
       headers: {
-        'X-API-Key': remoteApiKey,
-        'Content-Type': 'application/json',
+        "X-API-Key": remoteApiKey,
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({})) as { error?: string };
+      const errorData = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
       throw new Error(errorData.error || `HTTP ${response.status}`);
     }
 
@@ -232,21 +324,24 @@ export async function postRemoteAPI(
  */
 export async function deleteRemoteAPI(endpoint: string): Promise<unknown> {
   if (!isRemoteEnabled()) {
-    throw new Error('Remote search not configured');
+    throw new Error("Remote search not configured");
   }
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REMOTE_TIMEOUT_MS);
 
   try {
-    const response = await fetch(`${remoteApiUrl}${endpoint}`, {
-      method: 'DELETE',
-      headers: { 'X-API-Key': remoteApiKey },
+    const resolvedEndpoint = resolveEndpoint(endpoint);
+    const response = await fetch(`${remoteApiUrl}${resolvedEndpoint}`, {
+      method: "DELETE",
+      headers: { "X-API-Key": remoteApiKey },
       signal: controller.signal,
     });
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({})) as { error?: string };
+      const errorData = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
       throw new Error(errorData.error || `HTTP ${response.status}`);
     }
 
@@ -264,25 +359,22 @@ export async function deleteRemoteAPI(endpoint: string): Promise<unknown> {
  */
 export async function fetchObservationsByIds(ids: number[]): Promise<unknown> {
   if (!isRemoteEnabled()) {
-    throw new Error('Remote search not configured');
+    throw new Error("Remote search not configured");
   }
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REMOTE_TIMEOUT_MS);
 
   try {
-    const response = await fetch(
-      `${remoteApiUrl}/api/observations/batch`,
-      {
-        method: 'POST',
-        headers: {
-          'X-API-Key': remoteApiKey,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ ids }),
-        signal: controller.signal,
-      }
-    );
+    const response = await fetch(`${remoteApiUrl}/api/observations/batch`, {
+      method: "POST",
+      headers: {
+        "X-API-Key": remoteApiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ids }),
+      signal: controller.signal,
+    });
 
     if (!response.ok) {
       throw new Error(`Remote API error (${response.status})`);
@@ -303,7 +395,7 @@ export async function fetchObservationsByIds(ids: number[]): Promise<unknown> {
 export function wrapError(error: unknown): ToolResponse {
   const message = error instanceof Error ? error.message : String(error);
   return {
-    content: [{ type: 'text' as const, text: `Error: ${message}` }],
+    content: [{ type: "text" as const, text: `Error: ${message}` }],
     isError: true,
   };
 }
@@ -316,6 +408,6 @@ export function wrapError(error: unknown): ToolResponse {
  */
 export function wrapSuccess(text: string): ToolResponse {
   return {
-    content: [{ type: 'text' as const, text }],
+    content: [{ type: "text" as const, text }],
   };
 }

--- a/src/mcp/audit-logger.ts
+++ b/src/mcp/audit-logger.ts
@@ -1,0 +1,47 @@
+/**
+ * MCP Audit Logger
+ *
+ * Structured audit logging for tool invocations.
+ * Addresses Finding #7 (CWE-778): No structured audit logging.
+ *
+ * Outputs single-line JSON to stderr (stdout reserved for JSON-RPC).
+ */
+
+interface AuditEntry {
+  ts: string;
+  tool: string;
+  args_keys: string[];
+  duration_ms: number;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Write a structured audit log entry to stderr.
+ */
+export function auditLog(
+  tool: string,
+  args: Record<string, unknown>,
+  durationMs: number,
+  success: boolean,
+  error?: string,
+): void {
+  const entry: AuditEntry = {
+    ts: new Date().toISOString(),
+    tool,
+    args_keys: Object.keys(args),
+    duration_ms: durationMs,
+    success,
+  };
+
+  if (error) {
+    // Truncate error messages to avoid log bloat
+    entry.error = error.length > 200 ? error.slice(0, 200) + "..." : error;
+  }
+
+  try {
+    process.stderr.write(`[audit] ${JSON.stringify(entry)}\n`);
+  } catch {
+    // Never let logging failures propagate
+  }
+}

--- a/src/mcp/handlers/status-handler.ts
+++ b/src/mcp/handlers/status-handler.ts
@@ -4,7 +4,7 @@
  * Diagnostic tool for checking MemForge client configuration and connectivity.
  */
 
-import type { ToolDefinition } from '../types';
+import type { ToolDefinition } from "../types";
 import {
   getConfigSource,
   getRemoteUrl,
@@ -12,41 +12,41 @@ import {
   isRemoteEnabled,
   getRole,
   wrapSuccess,
-} from '../api-client';
+} from "../api-client";
 
 /**
  * Mask API key for display.
  */
 function maskKey(key: string): string {
-  if (!key) return '(not set)';
-  if (key.length <= 8) return '****';
-  return key.slice(0, 4) + '****' + key.slice(-4);
+  if (!key) return "(not set)";
+  return `configured (${key.length} chars)`;
 }
 
 /** mem_status tool definition */
 export const memStatus: ToolDefinition = {
-  name: 'mem_status',
-  description: 'Check MemForge client status: config source, API key, server connectivity, and auth validity.',
+  name: "mem_status",
+  description:
+    "Check MemForge client status: config source, API key, server connectivity, and auth validity.",
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {},
   },
   handler: async () => {
-    const lines: string[] = ['## MemForge Client Status\n'];
+    const lines: string[] = ["## MemForge Client Status\n"];
 
     // Config source
     const source = getConfigSource();
-    lines.push(`**Config:** ${source || 'not found'}`);
+    lines.push(`**Config:** ${source || "not found"}`);
     lines.push(`**Role:** ${getRole()}`);
     lines.push(`**API Key:** ${maskKey(getApiKey())}`);
     lines.push(`**Server:** ${getRemoteUrl()}`);
-    lines.push('');
+    lines.push("");
 
     if (!isRemoteEnabled()) {
-      lines.push('**Status:** Not configured');
-      lines.push('');
+      lines.push("**Status:** Not configured");
+      lines.push("");
       lines.push('Run `bun run setup "your-api-key"` to configure.');
-      return wrapSuccess(lines.join('\n'));
+      return wrapSuccess(lines.join("\n"));
     }
 
     // Connectivity check
@@ -63,7 +63,9 @@ export const memStatus: ToolDefinition = {
       const latency = Date.now() - start;
 
       if (!healthResponse.ok) {
-        lines.push(`**Connectivity:** Server returned ${healthResponse.status}`);
+        lines.push(
+          `**Connectivity:** Server returned ${healthResponse.status}`,
+        );
         lines.push(`**Latency:** ${latency}ms`);
       } else {
         lines.push(`**Connectivity:** OK`);
@@ -72,10 +74,10 @@ export const memStatus: ToolDefinition = {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       lines.push(`**Connectivity:** Failed - ${message}`);
-      lines.push('');
-      lines.push('Check your network or server URL.');
+      lines.push("");
+      lines.push("Check your network or server URL.");
       clearTimeout(timeoutId);
-      return wrapSuccess(lines.join('\n'));
+      return wrapSuccess(lines.join("\n"));
     } finally {
       clearTimeout(timeoutId);
     }
@@ -86,7 +88,7 @@ export const memStatus: ToolDefinition = {
 
     try {
       const authResponse = await fetch(`${serverUrl}/api/stats`, {
-        headers: { 'X-API-Key': apiKey },
+        headers: { "X-API-Key": apiKey },
         signal: authController.signal,
       });
 
@@ -94,8 +96,10 @@ export const memStatus: ToolDefinition = {
         lines.push(`**Auth:** Valid`);
       } else if (authResponse.status === 401 || authResponse.status === 403) {
         lines.push(`**Auth:** Invalid API key (${authResponse.status})`);
-        lines.push('');
-        lines.push('Get a valid key at: https://memclaude.thaicloud.ai/settings');
+        lines.push("");
+        lines.push(
+          "Get a valid key at: https://memclaude.thaicloud.ai/settings",
+        );
       } else {
         lines.push(`**Auth:** Server error (${authResponse.status})`);
       }
@@ -106,7 +110,7 @@ export const memStatus: ToolDefinition = {
       clearTimeout(authTimeoutId);
     }
 
-    return wrapSuccess(lines.join('\n'));
+    return wrapSuccess(lines.join("\n"));
   },
 };
 

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -17,15 +17,17 @@
  * - handlers/ - Tool handlers
  */
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+} from "@modelcontextprotocol/sdk/types.js";
 
-import { initializeApiKey, isRemoteEnabled, getRemoteUrl } from './api-client';
-import { getAllTools } from './handlers';
+import { initializeApiKey, isRemoteEnabled, getRemoteUrl } from "./api-client";
+import { getAllTools } from "./handlers";
+import { validateToolInput } from "./validation";
+import { auditLog } from "./audit-logger";
 
 // Redirect console.log to stderr (MCP uses stdout for JSON-RPC)
 const _originalConsoleLog = console.log;
@@ -38,7 +40,7 @@ initializeApiKey();
 if (isRemoteEnabled()) {
   console.log(`Remote search enabled: ${getRemoteUrl()}`);
 } else {
-  console.log('Remote search disabled (no API key)');
+  console.log("Remote search disabled (no API key)");
 }
 
 // Get all tool definitions
@@ -47,14 +49,14 @@ const tools = getAllTools();
 // Create MCP server
 const server = new Server(
   {
-    name: 'memforge-client',
-    version: '1.0.0',
+    name: "memforge-client",
+    version: "1.0.0",
   },
   {
     capabilities: {
       tools: {},
     },
-  }
+  },
 );
 
 // Register tools/list handler
@@ -76,12 +78,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     throw new Error(`Unknown tool: ${request.params.name}`);
   }
 
+  const rawArgs = (request.params.arguments || {}) as Record<string, unknown>;
+  const start = Date.now();
+
+  // Validate input before handler execution
+  let validatedArgs: Record<string, unknown>;
   try {
-    return await tool.handler((request.params.arguments || {}) as Record<string, unknown>);
+    validatedArgs = validateToolInput(request.params.name, rawArgs);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    auditLog(request.params.name, rawArgs, Date.now() - start, false, message);
     return {
-      content: [{ type: 'text' as const, text: `Tool execution failed: ${message}` }],
+      content: [{ type: "text" as const, text: message }],
+      isError: true,
+    };
+  }
+
+  try {
+    const result = await tool.handler(validatedArgs);
+    auditLog(request.params.name, rawArgs, Date.now() - start, true);
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    auditLog(request.params.name, rawArgs, Date.now() - start, false, message);
+    return {
+      content: [
+        { type: "text" as const, text: `Tool execution failed: ${message}` },
+      ],
       isError: true,
     };
   }
@@ -91,10 +114,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log('MemForge Client MCP server started');
+  console.log("MemForge Client MCP server started");
 }
 
 main().catch((error) => {
-  console.error('Fatal error:', error);
+  console.error("Fatal error:", error);
   process.exit(1);
 });

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -1,0 +1,185 @@
+/**
+ * MCP Tool Input Validation
+ *
+ * Zod schemas for runtime validation of all MCP tool inputs.
+ * Addresses Finding #2 (CWE-20): inputSchema is LLM hint only,
+ * this module enforces validation before handler execution.
+ */
+
+import { z } from "zod";
+
+// Reusable field schemas
+const dateField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD format")
+  .optional();
+const tzField = z
+  .string()
+  .regex(/^[+-]\d{2}:\d{2}$|^Z$/, "Expected timezone offset like +07:00 or Z")
+  .optional();
+const limitField = (max: number, defaultVal?: number) => {
+  const base = z.coerce.number().int().min(1).max(max);
+  return defaultVal !== undefined
+    ? base.optional().default(defaultVal)
+    : base.optional();
+};
+
+// Tool schemas
+const schemas: Record<string, z.ZodType> = {
+  mem_status: z.object({}).passthrough(),
+
+  mem_semantic_search: z.object({
+    q: z.string().min(1).max(2000),
+    limit: limitField(50, 10),
+    mode: z.enum(["hybrid", "fts", "vector"]).optional().default("hybrid"),
+    vector_weight: z.coerce.number().min(0).max(1).optional(),
+    dateStart: dateField,
+    dateEnd: dateField,
+    tz: tzField,
+    offset: z.coerce.number().int().min(0).optional(),
+    include_shared: z.boolean().optional(),
+  }),
+
+  mem_hybrid_search: z.object({
+    q: z.string().min(1).max(2000),
+    limit: limitField(50, 10),
+    vector_weight: z.coerce.number().min(0).max(1).optional(),
+    dateStart: dateField,
+    dateEnd: dateField,
+    tz: tzField,
+    offset: z.coerce.number().int().min(0).optional(),
+    include_shared: z.boolean().optional(),
+  }),
+
+  mem_vector_search: z.object({
+    q: z.string().min(1).max(2000),
+    limit: limitField(50, 10),
+    dateStart: dateField,
+    dateEnd: dateField,
+    tz: tzField,
+    offset: z.coerce.number().int().min(0).optional(),
+    include_shared: z.boolean().optional(),
+  }),
+
+  mem_search: z.object({
+    query: z.string().min(1).max(2000),
+    limit: limitField(50, 10),
+    project: z.string().max(200).optional(),
+    type: z.string().max(100).optional(),
+    dateStart: dateField,
+    dateEnd: dateField,
+    tz: tzField,
+    offset: z.coerce.number().int().min(0).optional(),
+    include_shared: z.boolean().optional(),
+  }),
+
+  mem_semantic_get: z.object({
+    id: z.coerce.number().int().min(1),
+  }),
+
+  mem_semantic_recent: z.object({
+    limit: limitField(100, 20),
+  }),
+
+  mem_timeline: z
+    .object({
+      anchor: z.coerce.number().int().min(1).optional(),
+      query: z.string().max(2000).optional(),
+      depth_before: z.coerce.number().int().min(0).max(50).optional(),
+      depth_after: z.coerce.number().int().min(0).max(50).optional(),
+      project: z.string().max(200).optional(),
+    })
+    .refine(
+      (data) =>
+        data.anchor !== undefined ||
+        (data.query !== undefined && data.query.length > 0),
+      { message: "Either anchor or query must be provided" },
+    ),
+
+  mem_get_observations: z.object({
+    ids: z.array(z.coerce.number().int().min(1)).min(1).max(200),
+  }),
+
+  mem_entity_lookup: z.object({
+    name: z.string().min(1).max(200),
+  }),
+
+  mem_triplets_query: z.object({
+    subject: z.string().max(200).optional(),
+    predicate: z
+      .enum(["is_type", "belongs_to", "modifies", "relates_to"])
+      .optional(),
+    object: z.string().max(200).optional(),
+    limit: limitField(500, 100),
+  }),
+
+  mem_ingest: z
+    .object({
+      provider: z
+        .enum(["cursor", "aider", "codex", "openai", "chatgpt", "generic"])
+        .optional()
+        .default("generic"),
+      item: z
+        .object({
+          title: z.string().min(1).max(500),
+          content: z.string().max(10000).optional(),
+          narrative: z.string().max(10000).optional(),
+          type: z.string().max(100).optional(),
+          project: z.string().max(200).optional(),
+          files_read: z.array(z.string().max(500)).max(100).optional(),
+          files_modified: z.array(z.string().max(500)).max(100).optional(),
+        })
+        .optional(),
+      items: z
+        .array(
+          z.object({
+            title: z.string().min(1).max(500),
+            content: z.string().max(10000).optional(),
+            narrative: z.string().max(10000).optional(),
+            type: z.string().max(100).optional(),
+            project: z.string().max(200).optional(),
+          }),
+        )
+        .max(100)
+        .optional(),
+    })
+    .refine(
+      (data) =>
+        data.item !== undefined ||
+        (data.items !== undefined && data.items.length > 0),
+      { message: "Either item or items must be provided" },
+    ),
+
+  mem_workflow_suggest: z.object({
+    query: z.string().max(2000).optional(),
+    limit: limitField(20, 5),
+  }),
+};
+
+/**
+ * Validate tool input against its Zod schema.
+ * Returns the parsed (coerced) args on success, or throws with a descriptive message.
+ */
+export function validateToolInput(
+  toolName: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const schema = schemas[toolName];
+  if (!schema) {
+    // No schema defined = no validation (shouldn't happen for known tools)
+    return args;
+  }
+
+  const result = schema.safeParse(args);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => {
+        const path = issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+        return `${path}${issue.message}`;
+      })
+      .join("; ");
+    throw new Error(`Invalid input: ${issues}`);
+  }
+
+  return result.data as Record<string, unknown>;
+}

--- a/src/sync/sync-manager.ts
+++ b/src/sync/sync-manager.ts
@@ -9,20 +9,26 @@
  * when Claude Code sessions begin and end.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
-import { homedir } from 'os';
-import { join, dirname } from 'path';
-import { spawn } from 'child_process';
-import { fileURLToPath } from 'url';
-import { openSync } from 'fs';
-import { resolveConfigPath } from '../mcp/api-client';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+} from "fs";
+import { homedir } from "os";
+import { join, dirname } from "path";
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+import { openSync } from "fs";
+import { resolveConfigPath } from "../mcp/api-client";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PLUGIN_ROOT = join(__dirname, '../..');
-const CLAUDE_MEM_DIR = join(homedir(), '.claude-mem');
-const PID_FILE = join(CLAUDE_MEM_DIR, 'memforge-sync.pid');
-const LOG_FILE = join(CLAUDE_MEM_DIR, 'memforge-sync.log');
-const DB_WATCHER_PATH = join(__dirname, 'db-watcher.ts');
+const PLUGIN_ROOT = join(__dirname, "../..");
+const CLAUDE_MEM_DIR = join(homedir(), ".claude-mem");
+const PID_FILE = join(CLAUDE_MEM_DIR, "memforge-sync.pid");
+const LOG_FILE = join(CLAUDE_MEM_DIR, "memforge-sync.log");
+const DB_WATCHER_PATH = join(__dirname, "db-watcher.ts");
 
 /**
  * Resolve the full path to the bun executable.
@@ -30,15 +36,15 @@ const DB_WATCHER_PATH = join(__dirname, 'db-watcher.ts');
  */
 function resolveBunPath(): string {
   // If currently running under bun, use the same executable
-  if (process.execPath && process.execPath.endsWith('bun')) {
+  if (process.execPath && process.execPath.endsWith("bun")) {
     return process.execPath;
   }
 
   // Check common bun install locations
   const candidates = [
-    join(homedir(), '.bun', 'bin', 'bun'),
-    '/usr/local/bin/bun',
-    '/usr/bin/bun',
+    join(homedir(), ".bun", "bin", "bun"),
+    "/usr/local/bin/bun",
+    "/usr/bin/bun",
   ];
 
   for (const candidate of candidates) {
@@ -46,7 +52,7 @@ function resolveBunPath(): string {
   }
 
   // Fallback to bare 'bun' (hope it's in PATH)
-  return 'bun';
+  return "bun";
 }
 
 interface PidInfo {
@@ -59,11 +65,13 @@ interface PidInfo {
  * Output a hook-compatible JSON response.
  */
 function hookResponse(message: string): void {
-  console.log(JSON.stringify({
-    continue: true,
-    suppressOutput: true,
-    message
-  }));
+  console.log(
+    JSON.stringify({
+      continue: true,
+      suppressOutput: true,
+      message,
+    }),
+  );
 }
 
 /**
@@ -81,7 +89,7 @@ function ensureDir(): void {
 function readPidInfo(): PidInfo | null {
   try {
     if (!existsSync(PID_FILE)) return null;
-    return JSON.parse(readFileSync(PID_FILE, 'utf-8'));
+    return JSON.parse(readFileSync(PID_FILE, "utf-8"));
   } catch {
     return null;
   }
@@ -99,6 +107,35 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+/** Env vars allowed for the child watcher process */
+const ENV_ALLOWLIST = [
+  "HOME",
+  "PATH",
+  "USER",
+  "LOGNAME",
+  "LANG",
+  "LC_ALL",
+  "NODE_ENV",
+  "BUN_INSTALL",
+  "CLAUDE_MEM_API_KEY", // watcher needs API key for sync
+  "CLAUDE_MEM_REMOTE_URL", // watcher needs server URL for sync
+  "MEMFORGE_ALLOW_CUSTOM_URL", // forwarded: watcher uses api-client.ts for self-hosted deployments
+];
+
+/**
+ * Build a restricted env object for the child process.
+ * Only passes allowlisted variables to prevent leaking secrets.
+ */
+function buildRestrictedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of ENV_ALLOWLIST) {
+    if (process.env[key]) {
+      env[key] = process.env[key]!;
+    }
+  }
+  return env;
+}
+
 /**
  * Start the database watcher as a detached background process.
  */
@@ -106,19 +143,19 @@ function start(): void {
   // Check config exists
   const configPath = resolveConfigPath();
   if (!configPath) {
-    hookResponse('Sync not configured. Run: bun run setup');
+    hookResponse("Sync not configured. Run: bun run setup");
     return;
   }
 
   // Check if sync is enabled in config
   try {
-    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
     if (!config.syncEnabled) {
-      hookResponse('Sync disabled in config');
+      hookResponse("Sync disabled in config");
       return;
     }
   } catch {
-    hookResponse('Failed to read config');
+    hookResponse("Failed to read config");
     return;
   }
 
@@ -131,25 +168,29 @@ function start(): void {
 
   // Clean up stale PID file
   if (pidInfo) {
-    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+    try {
+      unlinkSync(PID_FILE);
+    } catch {
+      /* ignore */
+    }
   }
 
   ensureDir();
 
   // Open log file for stdout/stderr redirection
-  const logFd = openSync(LOG_FILE, 'a');
+  const logFd = openSync(LOG_FILE, "a");
 
   // Spawn detached watcher process with resolved bun path
   const bunPath = resolveBunPath();
   const child = spawn(bunPath, [DB_WATCHER_PATH], {
     detached: true,
-    stdio: ['ignore', logFd, logFd],
+    stdio: ["ignore", logFd, logFd],
     cwd: PLUGIN_ROOT,
-    env: { ...process.env }
+    env: buildRestrictedEnv(),
   });
 
   if (!child.pid) {
-    hookResponse('Failed to start watcher');
+    hookResponse("Failed to start watcher");
     return;
   }
 
@@ -157,7 +198,7 @@ function start(): void {
   const info: PidInfo = {
     pid: child.pid,
     startedAt: new Date().toISOString(),
-    pluginRoot: PLUGIN_ROOT
+    pluginRoot: PLUGIN_ROOT,
   };
   writeFileSync(PID_FILE, JSON.stringify(info, null, 2));
 
@@ -174,13 +215,13 @@ function stop(): void {
   const pidInfo = readPidInfo();
 
   if (!pidInfo) {
-    hookResponse('Watcher not running (no PID file)');
+    hookResponse("Watcher not running (no PID file)");
     return;
   }
 
   if (isProcessAlive(pidInfo.pid)) {
     try {
-      process.kill(pidInfo.pid, 'SIGTERM');
+      process.kill(pidInfo.pid, "SIGTERM");
     } catch (err) {
       hookResponse(`Failed to stop watcher: ${err}`);
       return;
@@ -188,7 +229,11 @@ function stop(): void {
   }
 
   // Remove PID file
-  try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+  try {
+    unlinkSync(PID_FILE);
+  } catch {
+    /* ignore */
+  }
 
   hookResponse(`Watcher stopped (PID: ${pidInfo.pid})`);
 }
@@ -200,12 +245,12 @@ function status(): void {
   const pidInfo = readPidInfo();
 
   if (!pidInfo) {
-    console.log('Status: NOT RUNNING (no PID file)');
+    console.log("Status: NOT RUNNING (no PID file)");
     return;
   }
 
   const alive = isProcessAlive(pidInfo.pid);
-  console.log(`Status: ${alive ? 'RUNNING' : 'STOPPED (stale PID)'}`);
+  console.log(`Status: ${alive ? "RUNNING" : "STOPPED (stale PID)"}`);
   console.log(`PID: ${pidInfo.pid}`);
   console.log(`Started: ${pidInfo.startedAt}`);
   console.log(`Plugin: ${pidInfo.pluginRoot}`);
@@ -213,8 +258,12 @@ function status(): void {
 
   if (!alive) {
     // Clean up stale PID file
-    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
-    console.log('(Cleaned up stale PID file)');
+    try {
+      unlinkSync(PID_FILE);
+    } catch {
+      /* ignore */
+    }
+    console.log("(Cleaned up stale PID file)");
   }
 }
 
@@ -223,17 +272,17 @@ if (import.meta.main) {
   const command = process.argv[2];
 
   switch (command) {
-    case 'start':
+    case "start":
       start();
       break;
-    case 'stop':
+    case "stop":
       stop();
       break;
-    case 'status':
+    case "status":
       status();
       break;
     default:
-      console.log('Usage: sync-manager <start|stop|status>');
+      console.log("Usage: sync-manager <start|stop|status>");
       process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

Fixes all 7 security findings from #13 (MCP static analysis on memforge-client v1.1.0).

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | **MEDIUM** | SSRF — `serverUrl` passed to `fetch()` with no allowlist | `validateServerUrl()` with HTTPS enforcement, private IP blocking, hostname allowlist |
| 2 | **MEDIUM** | No runtime input validation on 12 MCP tools | Zod schemas for all 12 tools in `validation.ts`, centralized enforcement in request handler |
| 3 | **MEDIUM** | `ENDPOINT_MAP` fallback passes raw endpoint | `resolveEndpoint()` with strict allowlist + path normalization against traversal |
| 4 | LOW | `spawn()` inherits full `process.env` | `buildRestrictedEnv()` — only allowlisted vars forwarded to child process |
| 5 | LOW | `mem_status` exposes partial API key | `maskKey()` now returns `"configured (N chars)"` — zero key characters exposed |
| 6 | LOW | `mem_ingest` no batch enforcement | Zod schema enforces required `title`, batch cap of 100, `item` or `items` required |
| 7 | LOW | No structured audit logging | `audit-logger.ts` writes structured JSON to stderr for every tool invocation |

### New files
- `src/mcp/validation.ts` — Zod schemas for all 12 tools
- `src/mcp/audit-logger.ts` — structured audit logging
- `src/mcp/__tests__/validation.test.ts` — 32 validation tests
- `src/mcp/__tests__/audit-logger.test.ts` — 5 audit logger tests

### Security notes
- Self-hosted deployments can bypass URL allowlist with `MEMFORGE_ALLOW_CUSTOM_URL=1`
- `resolveEndpoint()` normalizes paths via `new URL()` to prevent `..` traversal
- Endpoint allowlist applied to `callRemoteAPI`, `postRemoteAPI`, and `deleteRemoteAPI`
- Audit log only records arg key names (not values) to prevent data leakage

## Test plan
- [x] 37 unit tests passing (`bun test src/mcp/__tests__/`)
- [x] Build verification (`bun build` for mcp-server and sync-manager)
- [ ] Manual: start MCP server, invoke each tool via Claude Code, confirm no regressions
- [ ] Manual: start sync-manager, verify watcher process starts with restricted env
- [ ] Manual: `mem_status` shows zero API key characters

Closes #13