### PR TITLE
feat: sync client with server v1.4.0 — 3 new MCP tools (#19)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 MemForge Client is a companion plugin that connects to the [MemForge](https://memclaude.thaicloud.ai) server, providing:
 
-- **15 MCP tools** for semantic search, observation retrieval, memory snapshots, and diagnostics
+- **16 MCP tools** for semantic search, cross-project knowledge, team collaboration, and diagnostics
 - **Real-time sync** from local claude-mem database to remote server
 - **Hybrid search** combining vector embeddings and full-text search
 - **Knowledge graph** with entity lookup and triplet queries
@@ -16,6 +16,7 @@ MemForge Client is a companion plugin that connects to the [MemForge](https://me
 ### Prerequisites
 
 1. **Bun runtime** - Install from https://bun.sh:
+
    ```bash
    curl -fsSL https://bun.sh/install | bash
    ```
@@ -70,6 +71,7 @@ bun run setup
 ```
 
 Then add to Claude Code:
+
 ```
 /plugin add /path/to/c-memforge
 ```
@@ -84,6 +86,7 @@ bun run sync
 ```
 
 The sync service:
+
 - Polls local database every 2 seconds
 - Syncs new observations to remote server
 - Retries failed syncs automatically
@@ -97,45 +100,44 @@ The sync service:
 
 ### Diagnostic Tools
 
-| Tool | Description |
-|------|-------------|
+| Tool         | Description                                            |
+| ------------ | ------------------------------------------------------ |
 | `mem_status` | Check config, connectivity, auth validity, and latency |
 
 ### Search Tools
 
-| Tool | Description | Recommendation |
-|------|-------------|----------------|
-| `mem_search` | Full-text search with filters | Fast (1-3s) |
-| `mem_hybrid_search` | Hybrid search with RRF ranking | Use `vector_weight=0.2` |
-| `mem_semantic_search` | Hybrid with mode selection | Flexible |
-| `mem_vector_search` | Pure vector/embedding search | Slowest (10-38s) |
+| Tool                  | Description                    | Recommendation          |
+| --------------------- | ------------------------------ | ----------------------- |
+| `mem_search`          | Full-text search with filters  | Fast (1-3s)             |
+| `mem_hybrid_search`   | Hybrid search with RRF ranking | Use `vector_weight=0.2` |
+| `mem_semantic_search` | Hybrid with mode selection     | Flexible                |
+| `mem_vector_search`   | Pure vector/embedding search   | Slowest (10-38s)        |
 
 All search tools support `offset` parameter for pagination.
 
 ### Observation Tools
 
-| Tool | Description |
-|------|-------------|
-| `mem_semantic_get` | Get observation by ID |
-| `mem_semantic_recent` | Get recent observations |
-| `mem_timeline` | Get context around an observation |
-| `mem_get_observations` | Batch fetch observations by IDs |
+| Tool                   | Description                       |
+| ---------------------- | --------------------------------- |
+| `mem_semantic_get`     | Get observation by ID             |
+| `mem_semantic_recent`  | Get recent observations           |
+| `mem_timeline`         | Get context around an observation |
+| `mem_get_observations` | Batch fetch observations by IDs   |
 
 ### Entity Tools
 
-| Tool | Description |
-|------|-------------|
-| `mem_entity_lookup` | Find triplets by entity name |
+| Tool                 | Description                     |
+| -------------------- | ------------------------------- |
+| `mem_entity_lookup`  | Find triplets by entity name    |
 | `mem_triplets_query` | Query SPO triplets with filters |
 
-### Snapshot Tools
+### Context & Knowledge Tools
 
-| Tool | Description | Access |
-|------|-------------|--------|
-| `mem_snapshot_create` | Create memory snapshot | All |
-| `mem_snapshot_list` | List all snapshots | All |
-| `mem_snapshot_restore` | Restore from snapshot | Admin only |
-| `mem_snapshot_delete` | Delete a snapshot | Admin only |
+| Tool                 | Description                                               |
+| -------------------- | --------------------------------------------------------- |
+| `mem_cross_project`  | Find observations from other projects via concept overlap |
+| `mem_team_knowledge` | Search team knowledge pool (shared by team members)       |
+| `mem_stable_context` | Get stable observation log for prompt caching             |
 
 ---
 
@@ -155,13 +157,13 @@ Configuration is stored in `~/.memforge/config.json`:
 
 ### Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `apiKey` | Your MemForge API key | (required) |
-| `serverUrl` | MemForge server URL | `https://memclaude.thaicloud.ai` |
-| `syncEnabled` | Enable real-time sync | `true` |
-| `pollInterval` | Sync poll interval in ms | `2000` |
-| `role` | Access level (`client` or `admin`) | `client` |
+| Option         | Description                        | Default                          |
+| -------------- | ---------------------------------- | -------------------------------- |
+| `apiKey`       | Your MemForge API key              | (required)                       |
+| `serverUrl`    | MemForge server URL                | `https://memclaude.thaicloud.ai` |
+| `syncEnabled`  | Enable real-time sync              | `true`                           |
+| `pollInterval` | Sync poll interval in ms           | `2000`                           |
+| `role`         | Access level (`client` or `admin`) | `client`                         |
 
 ### Self-Hosted Server
 
@@ -180,13 +182,14 @@ To use your own MemForge server:
 
 Search latency varies by mode. Choose the right mode for your needs:
 
-| Mode | Typical Latency | Best For |
-|------|----------------|----------|
-| `fts` (full-text) | 1-3s | Keyword search, fastest |
-| `hybrid` | 5-15s | Balanced relevance |
-| `vector` | 10-38s | Semantic similarity, slowest |
+| Mode              | Typical Latency | Best For                     |
+| ----------------- | --------------- | ---------------------------- |
+| `fts` (full-text) | 1-3s            | Keyword search, fastest      |
+| `hybrid`          | 5-15s           | Balanced relevance           |
+| `vector`          | 10-38s          | Semantic similarity, slowest |
 
 **Tips for faster searches:**
+
 - Use `mode: "fts"` in `mem_semantic_search` for fast keyword search
 - Add `dateStart`/`dateEnd` filters to narrow results
 - Use lower `limit` values (5-10 instead of 50)
@@ -224,6 +227,7 @@ graph TB
 ```
 
 **Components:**
+
 - **claude-mem plugin**: Local SQLite database storing observations
 - **memforge-client**: Sync service that polls local DB every 2s and pushes to remote
 - **MemForge API**: Remote server handling sync and search requests
@@ -262,12 +266,12 @@ sequenceDiagram
 
 ## Scripts
 
-| Script | Description |
-|--------|-------------|
+| Script                    | Description                              |
+| ------------------------- | ---------------------------------------- |
 | `bun run setup [api-key]` | Configure API key (interactive or quick) |
-| `bun run sync` | Start database watcher |
-| `bun run check` | Check dependencies |
-| `bun run mcp` | Run MCP server directly |
+| `bun run sync`            | Start database watcher                   |
+| `bun run check`           | Check dependencies                       |
+| `bun run mcp`             | Run MCP server directly                  |
 
 ---
 
@@ -280,6 +284,7 @@ Run `bun run setup` to configure your API key, or use `mem_status` tool to diagn
 ### "Required: thedotmack/claude-mem plugin"
 
 Install the base plugin first:
+
 ```
 /plugin marketplace add thedotmack/claude-mem
 ```
@@ -287,6 +292,7 @@ Install the base plugin first:
 ### "bun: command not found"
 
 Install Bun runtime:
+
 ```bash
 curl -fsSL https://bun.sh/install | bash
 source ~/.bashrc  # or restart terminal
@@ -301,6 +307,7 @@ claude plugin marketplace add https://github.com/pitimon/c-memforge.git
 ```
 
 Or configure git to use HTTPS for all GitHub operations:
+
 ```bash
 git config --global url."https://github.com/".insteadOf git@github.com:
 ```
@@ -330,6 +337,7 @@ claude plugin marketplace update pitimon-c-memforge
 ```
 
 Or inside Claude Code:
+
 ```
 /plugin marketplace update pitimon-c-memforge
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/src/mcp/handlers/context-handlers.ts
+++ b/src/mcp/handlers/context-handlers.ts
@@ -1,0 +1,180 @@
+/**
+ * Context Tool Handlers
+ *
+ * Client-side tools for cross-project knowledge (#326) and
+ * stable context retrieval (Phase 6.3).
+ */
+
+import type { ToolDefinition } from "../types";
+import { callRemoteAPI, wrapError, wrapSuccess } from "../api-client";
+
+// =============================================================================
+// Cross-Project Knowledge (#326)
+// =============================================================================
+
+interface CrossProjectResponse {
+  targetProject: string;
+  suggestions: Array<{
+    id: number;
+    title: string;
+    sourceProject: string;
+    type: string;
+    created_at: string;
+    sharedConceptCount: number;
+    sharedConcepts: string[];
+  }>;
+  projectOverlaps: Array<{
+    project: string;
+    sharedConceptCount: number;
+    topSharedConcepts: string[];
+    observationCount: number;
+  }>;
+  totalCandidates: number;
+}
+
+/** mem_cross_project tool definition */
+export const memCrossProject: ToolDefinition = {
+  name: "mem_cross_project",
+  description:
+    "Find relevant observations from other projects based on shared concepts. " +
+    "Uses Memgraph graph traversal to identify concept overlap between projects. " +
+    "Only returns your own observations across projects.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      project: {
+        type: "string",
+        description:
+          "Target project name — finds observations from OTHER projects that share concepts with this one",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of suggestions to return (default: 20)",
+      },
+      min_concepts: {
+        type: "number",
+        description:
+          "Minimum shared concepts required to qualify as a suggestion (default: 2)",
+      },
+    },
+    required: ["project"],
+  },
+  handler: async (args) => {
+    const project = args.project as string;
+    const limit = args.limit as number | undefined;
+    const min_concepts = args.min_concepts as number | undefined;
+
+    try {
+      const params: Record<string, unknown> = { project };
+      if (limit) params.limit = limit;
+      if (min_concepts) params.min_concepts = min_concepts;
+
+      const data = (await callRemoteAPI(
+        "/context/cross-project",
+        params,
+      )) as CrossProjectResponse;
+
+      if (!data.suggestions || data.suggestions.length === 0) {
+        return wrapSuccess(
+          `No cross-project knowledge found for project "${project}". ` +
+            "This project may not share concepts with other projects, or the graph may need time to sync.",
+        );
+      }
+
+      let output = `# Cross-Project Knowledge for "${project}"\n\n`;
+      output += `Found ${data.suggestions.length} relevant observations from ${data.projectOverlaps.length} other project(s).\n\n`;
+
+      if (data.projectOverlaps.length > 0) {
+        output += "## Project Overlap\n\n";
+        for (const overlap of data.projectOverlaps) {
+          output += `- **${overlap.project}**: ${overlap.sharedConceptCount} shared concepts, ${overlap.observationCount} relevant observations\n`;
+          output += `  Concepts: ${overlap.topSharedConcepts.join(", ")}\n`;
+        }
+        output += "\n";
+      }
+
+      output += "## Suggestions\n\n";
+      for (const s of data.suggestions) {
+        output += `### [${s.sourceProject}] ${s.title}\n`;
+        output += `- **Type**: ${s.type} | **Shared concepts**: ${s.sharedConceptCount}\n`;
+        output += `- **Concepts**: ${s.sharedConcepts.join(", ")}\n`;
+        output += `- **ID**: ${s.id} | **Date**: ${s.created_at}\n\n`;
+      }
+
+      return wrapSuccess(output);
+    } catch (error) {
+      return wrapError(error);
+    }
+  },
+};
+
+// =============================================================================
+// Stable Context (Phase 6.3)
+// =============================================================================
+
+interface StableContextResponse {
+  context: string;
+  entries: Array<Record<string, unknown>>;
+  total_tokens: number;
+  entry_count: number;
+  user: string;
+}
+
+/** mem_stable_context tool definition */
+export const memStableContext: ToolDefinition = {
+  name: "mem_stable_context",
+  description:
+    "Get the stable observation log for a session or project. " +
+    "Returns compressed, append-only context designed for prompt caching. " +
+    "Use this to load previous session context efficiently.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      sdk_session_id: {
+        type: "string",
+        description: "SDK session ID to retrieve context for",
+      },
+      project: {
+        type: "string",
+        description: "Project name to retrieve context for",
+      },
+    },
+  },
+  handler: async (args) => {
+    const sdk_session_id = args.sdk_session_id as string | undefined;
+    const project = args.project as string | undefined;
+
+    if (!sdk_session_id && !project) {
+      return wrapError(
+        new Error("Either sdk_session_id or project is required"),
+      );
+    }
+
+    try {
+      const params: Record<string, unknown> = {};
+      if (sdk_session_id) params.sdk_session_id = sdk_session_id;
+      if (project) params.project = project;
+
+      const data = (await callRemoteAPI(
+        "/context/stable",
+        params,
+      )) as StableContextResponse;
+
+      if (!data.context || data.entry_count === 0) {
+        return wrapSuccess(
+          "No stable context available for this session/project yet.",
+        );
+      }
+
+      const header = `# Stable Context (${data.entry_count} entries, ~${data.total_tokens} tokens)\n\n`;
+      return wrapSuccess(header + data.context);
+    } catch (error) {
+      return wrapError(error);
+    }
+  },
+};
+
+export const contextHandlers: ToolDefinition[] = [
+  memCrossProject,
+  memStableContext,
+];

--- a/src/mcp/handlers/index.ts
+++ b/src/mcp/handlers/index.ts
@@ -15,6 +15,8 @@ import { entityHandlers } from "./entity-handlers";
 import { statusHandlers } from "./status-handler";
 import { ingestHandlers } from "./ingest-handler";
 import { workflowHandlers } from "./workflow-handler";
+import { contextHandlers } from "./context-handlers";
+import { teamHandlers } from "./team-handlers";
 
 export {
   searchHandlers,
@@ -23,6 +25,8 @@ export {
   statusHandlers,
   ingestHandlers,
   workflowHandlers,
+  contextHandlers,
+  teamHandlers,
 };
 
 // Re-export individual handlers for direct imports
@@ -46,6 +50,8 @@ export { memStatus } from "./status-handler";
 
 export { memIngest } from "./ingest-handler";
 export { memWorkflowSuggest } from "./workflow-handler";
+export { memCrossProject, memStableContext } from "./context-handlers";
+export { memTeamKnowledge } from "./team-handlers";
 
 /**
  * Get all tool definitions for MCP server registration.
@@ -60,5 +66,7 @@ export function getAllTools(): ToolDefinition[] {
     ...entityHandlers,
     ...ingestHandlers,
     ...workflowHandlers,
+    ...contextHandlers,
+    ...teamHandlers,
   ];
 }

--- a/src/mcp/handlers/team-handlers.ts
+++ b/src/mcp/handlers/team-handlers.ts
@@ -1,0 +1,102 @@
+/**
+ * Team Knowledge Tool Handler (#327)
+ *
+ * Client-side tool for accessing team knowledge pool — shared
+ * observations from team members across projects.
+ */
+
+import type { ToolDefinition } from "../types";
+import { callRemoteAPI, wrapError, wrapSuccess } from "../api-client";
+
+interface TeamKnowledgeResponse {
+  team_id: number;
+  observations: Array<{
+    id: number;
+    title: string | null;
+    narrative: string | null;
+    type: string | null;
+    project: string | null;
+    created_at: string | null;
+    owner_user: string;
+    owner_schema: string;
+    permission: string;
+  }>;
+  total: number;
+  query: string | null;
+}
+
+/** mem_team_knowledge tool definition */
+export const memTeamKnowledge: ToolDefinition = {
+  name: "mem_team_knowledge",
+  description:
+    "Search the team knowledge pool — observations shared by team members. " +
+    "Use this to find what other agents/users on the same team have learned. " +
+    "Requires team membership.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      team_id: {
+        type: "number",
+        description: "Team ID to search knowledge pool for",
+      },
+      query: {
+        type: "string",
+        description:
+          "Optional text query to filter team knowledge (searches title + narrative)",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum results to return (default: 20)",
+      },
+    },
+    required: ["team_id"],
+  },
+  handler: async (args) => {
+    const teamId = args.team_id as number;
+    const query = args.query as string | undefined;
+    const limit = args.limit as number | undefined;
+
+    try {
+      const params: Record<string, unknown> = {};
+      if (query) params.q = query;
+      if (limit) params.limit = limit;
+
+      const data = (await callRemoteAPI(
+        `/api/teams/${teamId}/knowledge`,
+        params,
+      )) as TeamKnowledgeResponse;
+
+      if (!data.observations || data.observations.length === 0) {
+        const msg = query
+          ? `No team knowledge found matching "${query}" in team ${teamId}.`
+          : `No shared knowledge in team ${teamId} yet. Share observations using the share-team endpoint.`;
+        return wrapSuccess(msg);
+      }
+
+      let output = `# Team Knowledge Pool (Team ${teamId})\n\n`;
+      output += `Found ${data.observations.length} shared observations`;
+      if (data.query) output += ` matching "${data.query}"`;
+      output += ".\n\n";
+
+      for (const obs of data.observations) {
+        output += `### ${obs.title || "Untitled"}\n`;
+        output += `- **From**: ${obs.owner_user} | **Type**: ${obs.type || "unknown"} | **Project**: ${obs.project || "—"}\n`;
+        output += `- **ID**: ${obs.id} | **Date**: ${obs.created_at || "—"}\n`;
+        if (obs.narrative) {
+          const preview =
+            obs.narrative.length > 200
+              ? obs.narrative.slice(0, 200) + "..."
+              : obs.narrative;
+          output += `- ${preview}\n`;
+        }
+        output += "\n";
+      }
+
+      return wrapSuccess(output);
+    } catch (error) {
+      return wrapError(error);
+    }
+  },
+};
+
+export const teamHandlers: ToolDefinition[] = [memTeamKnowledge];


### PR DESCRIPTION
## Summary

Sync c-memforge client with server v1.4.0. Add 3 missing tools:

- **`mem_cross_project`** — find observations from other projects via Memgraph concept overlap (#326)
- **`mem_team_knowledge`** — search team knowledge pool shared by team members (#327)
- **`mem_stable_context`** — get stable observation log for prompt caching (Phase 6.3)

## Changes

| File | Change |
|------|--------|
| `context-handlers.ts` | **New** — `mem_cross_project` + `mem_stable_context` |
| `team-handlers.ts` | **New** — `mem_team_knowledge` |
| `index.ts` | Register + export new handlers |
| `README.md` | Fix stale snapshot section → context & knowledge tools, 15→16 count |
| `package.json` + `plugin.json` | 1.2.3 → 1.3.0 |

## Test plan

- [ ] `mem_cross_project` returns formatted results from server
- [ ] `mem_team_knowledge` returns team shared observations
- [ ] `mem_stable_context` returns observation log
- [ ] Existing 13 tools still work (no regression)

Closes #19