### PR TITLE
fix: add missing ALLOWED_API_PATHS for 3 new tools

### DIFF
--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -202,6 +202,8 @@ const ENDPOINT_MAP: Record<string, string> = {
   "/timeline": "/api/timeline",
   "/recent": "/api/observations",
   "/observation": "/api/observations/batch",
+  "/context/cross-project": "/api/context/cross-project",
+  "/context/stable": "/api/context/stable",
 };
 
 /** Allowed direct API paths (not in ENDPOINT_MAP) */
@@ -217,6 +219,9 @@ const ALLOWED_API_PATHS = new Set([
   "/api/search",
   "/api/search/hybrid",
   "/api/search/vector",
+  "/api/context/cross-project",
+  "/api/context/stable",
+  "/api/teams",
   "/health",
 ]);
 


### PR DESCRIPTION
## Summary
- Add ENDPOINT_MAP entries for `/context/cross-project` and `/context/stable` (used by `mem_cross_project` and `mem_stable_context`)
- Add `/api/teams` to `ALLOWED_API_PATHS` for prefix-matched `/api/teams/{id}/knowledge` (used by `mem_team_knowledge`)

## Root Cause
The client's SSRF-protection allowlist in `api-client.ts` rejected the 3 new endpoint paths added in v1.3.0, causing "Unknown endpoint" errors that were misleadingly reported as "Server endpoint not deployed".

## Test plan
- [ ] `mem_cross_project project=memforge` → returns suggestions or empty (not error)
- [ ] `mem_stable_context project=memforge` → returns context or empty
- [ ] `mem_team_knowledge team_id=1` → returns results or "not a member"
- [ ] All 16/16 tools PASS QA