### PR TITLE
fix: add /api/snapshots to SSRF allowlist

### DIFF
--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -222,6 +222,7 @@ const ALLOWED_API_PATHS = new Set([
   "/api/context/cross-project",
   "/api/context/stable",
   "/api/teams",
+  "/api/snapshots",
   "/health",
 ]);
 


### PR DESCRIPTION
## Summary

- Add `/api/snapshots` to `ALLOWED_API_PATHS` in `api-client.ts`
- Fixes all 4 snapshot tools throwing `Unknown endpoint: /api/snapshots`

## Test plan

- [ ] `bun build src/mcp/mcp-server.ts --target=bun` — no errors
- [ ] `mem_snapshot_list` tool returns results (not "Unknown endpoint")
- [ ] `mem_snapshot_create` with test name succeeds

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)