### PR TITLE
docs: fix tool count and add missing tools to README

### DIFF
--- a/.claude-plugin/CLAUDE.md
+++ b/.claude-plugin/CLAUDE.md
@@ -4,7 +4,7 @@ Persistent semantic memory for Claude Code, powered by the MemForge SaaS platfor
 
 ## MCP Tools Available
 
-This plugin provides 15 MCP tools for diagnostics, semantic search, and memory management:
+This plugin provides 16 MCP tools for diagnostics, semantic search, and memory management:
 
 ### Diagnostic Tools
 - `mem_status` - Check config, connectivity, auth, and latency
@@ -27,11 +27,14 @@ All search tools support `offset` parameter for pagination.
 - `mem_entity_lookup` - Find triplets by entity name
 - `mem_triplets_query` - Query SPO triplets with filters
 
-### Snapshot Tools
-- `mem_snapshot_create` - Create memory snapshot
-- `mem_snapshot_list` - List all snapshots
-- `mem_snapshot_restore` - Restore from snapshot (admin only)
-- `mem_snapshot_delete` - Delete a snapshot (admin only)
+### Context & Knowledge Tools
+- `mem_cross_project` - Find observations from other projects via concept overlap
+- `mem_team_knowledge` - Search team knowledge pool (shared by team members)
+- `mem_stable_context` - Get stable observation log for prompt caching
+
+### Data Tools
+- `mem_ingest` - Ingest observations into the server
+- `mem_workflow_suggest` - Suggest workflows based on context
 
 ## Configuration
 
@@ -40,7 +43,9 @@ Config is stored at `~/.memforge/config.json`. Run `bun run setup` to configure.
 Sync runs automatically inside the MCP server process when `syncEnabled: true`.
 
 ### Role-Based Access
-Set `"role": "admin"` in config to access destructive snapshot tools (restore/delete). Default is `"client"`.
+Set `"role": "admin"` in config to access admin features. Default is `"client"`.
+
+> **Note:** Snapshot tools (create/restore/delete) are available on the server-side MCP only, not in this client plugin.
 
 ## Sync (In-Process)
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ All search tools support `offset` parameter for pagination.
 | `mem_team_knowledge` | Search team knowledge pool (shared by team members)       |
 | `mem_stable_context` | Get stable observation log for prompt caching             |
 
+### Data Tools
+
+| Tool                   | Description                         |
+| ---------------------- | ----------------------------------- |
+| `mem_ingest`           | Ingest observations into the server |
+| `mem_workflow_suggest` | Suggest workflows based on context  |
+
 ---
 
 ## Configuration
@@ -211,7 +218,7 @@ graph TB
     MFC -->|HTTPS + API Key<br/>POST /api/sync/push| API
     API --> VDB
 
-    User[Claude Code] -.->|15 MCP Tools<br/>Search & Retrieve| API
+    User[Claude Code] -.->|16 MCP Tools<br/>Search & Retrieve| API
 
     style CM fill:#1a365d,stroke:#2d3748,stroke-width:2px,color:#fff
     style MFC fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
@@ -317,7 +324,7 @@ This is a known Claude Code issue ([#9719](https://github.com/anthropics/claude-
 
 ### Database locked
 
-The sync service uses read-only mode and should not conflict with claude-mem. If issues persist, restart the sync service.
+The sync poller uses read-only mode and should not conflict with claude-mem. If issues persist, restart Claude Code (which restarts the MCP server and sync poller).
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix tool count: 15 → 16 in `CLAUDE.md` and `README.md` mermaid diagram
- Add 2 missing tools to README: `mem_ingest`, `mem_workflow_suggest`
- Remove phantom snapshot tools from `CLAUDE.md` (removed from client since v1.1.1)
- Fix "sync service" → "sync poller" in troubleshooting section

## Test plan

- [ ] Count tools in README matches `getAllTools()` in `handlers/index.ts` (16)
- [ ] No stale references to `15 MCP`, `sync service`, `bun run sync`

Closes #26, closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)