### PR TITLE
feat(mem_status): Pipeline Health 4-layer diagnosis (Gap A/B/C)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ Restart to load the plugin. Verify with `mem_status` tool — should show connec
 
 ### Data & Workflow
 
-| Tool                   | Purpose                                       |
-| ---------------------- | --------------------------------------------- |
-| `mem_ingest`           | Push observations to the server               |
-| `mem_workflow_suggest` | Get workflow suggestions based on context     |
+| Tool                   | Purpose                                           |
+| ---------------------- | ------------------------------------------------- |
+| `mem_ingest`           | Push observations to the server                   |
+| `mem_workflow_suggest` | Get workflow suggestions based on context         |
 | `mem_status`           | Check config, connectivity, auth, tier, and quota |
 
 All tool responses include **workflow hints** (`suggested_next`) guiding you to the right follow-up tool.
@@ -126,12 +126,12 @@ All tool responses include **workflow hints** (`suggested_next`) guiding you to 
 
 Your API key is associated with a tier that determines available features:
 
-| Tier         | Observations | Search Modes        | Synthesis/day | Rate Limit |
-| ------------ | ------------ | ------------------- | ------------- | ---------- |
-| **Free**     | 5,000        | FTS only            | 10            | 60/min     |
-| **Pro**      | 100,000      | FTS + Vector + Hybrid | 200         | 300/min    |
-| **Team**     | Unlimited    | All + cross-user    | Unlimited     | 600/min    |
-| **Enterprise** | Unlimited  | All + SSO + audit   | Unlimited     | Custom     |
+| Tier           | Observations | Search Modes          | Synthesis/day | Rate Limit |
+| -------------- | ------------ | --------------------- | ------------- | ---------- |
+| **Free**       | 5,000        | FTS only              | 10            | 60/min     |
+| **Pro**        | 100,000      | FTS + Vector + Hybrid | 200           | 300/min    |
+| **Team**       | Unlimited    | All + cross-user      | Unlimited     | 600/min    |
+| **Enterprise** | Unlimited    | All + SSO + audit     | Unlimited     | Custom     |
 
 Run `mem_status` to see your current tier and quota usage. The server endpoints `/api/auth/me`, `/api/account`, and `/api/user/me` all return tier and quota details.
 
@@ -216,6 +216,33 @@ Restart Claude Code. The SyncPoller will log:
 ```
 
 Server-side deduplication prevents duplicates, so this is safe to run anytime.
+
+### Verify sync is actually working
+
+If you suspect the observation count on the MemForge UI is lower than it should be, run `mem_status` — it includes a **Pipeline Health** section that pinpoints which layer is failing. The numbers you see will reflect your own activity:
+
+```
+### Pipeline Health
+**Activity (last 24h):** N transcript file(s) modified
+**Captured (last 24h):** M obs in claude-mem.db (latest id=…)
+**Sync cursor:** obs #… (K unsynced)
+**Server (lifetime):** … obs accepted
+**Sync workers:** synced ok, 0 failed, 0 pending, circuit=closed
+
+✓ Healthy — all 4 layers aligned.
+```
+
+The 4 layers form a pipeline. A gap between adjacent layers points at a specific failure mode:
+
+| Gap   | Symptom                                                   | Likely cause                                                           | Where to look                                                          |
+| ----- | --------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **A** | transcripts > 0 but `Captured` is 0 (or `<<` transcripts) | claude-mem hooks not running — observations are never produced locally | `~/.claude/settings.json` PostToolUse hook + `~/.claude-mem/logs/`     |
+| **B** | `unsynced` is large or `circuit=open`                     | sync poller is behind or server unreachable                            | sync-poller stderr; check connectivity in the same `mem_status` output |
+| **C** | `failed > 0`                                              | server rejected uploads (quota, auth, malformed payload)               | tier quota above; API key validity; server logs                        |
+
+This is the **most common silent-failure mode**: claude-mem hook misconfiguration produces no observations at all, yet `mem_status` connectivity/auth/sync all show GREEN. The Pipeline Health section is what makes Gap A visible.
+
+If `Captured` keeps reporting 0 after Gap A is shown, re-check that `claude-mem` is installed and that `~/.claude-mem/claude-mem.db` exists and is being written to (mtime should advance during use).
 
 ### Upgrading from v1.x
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/src/mcp/__tests__/pipeline-health.test.ts
+++ b/src/mcp/__tests__/pipeline-health.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Tests for pipeline health diagnosis.
+ *
+ * Verifies the 4-layer matrix that distinguishes upstream-of-sync failures
+ * (Gap A: hooks not capturing) from sync failures (Gap B/C).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { Database } from "bun:sqlite";
+import {
+  computePipelineHealth,
+  renderPipelineHealth,
+  type PipelineHealthInputs,
+} from "../handlers/pipeline-health";
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "memforge-pipeline-test-"));
+}
+
+function createObservationsDb(path: string): Database {
+  const db = new Database(path);
+  db.run(`
+    CREATE TABLE observations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      type TEXT NOT NULL,
+      title TEXT,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL
+    )
+  `);
+  return db;
+}
+
+function insertObs(db: Database, id: number, ageSeconds: number): void {
+  const epoch = Math.floor(Date.now() / 1000) - ageSeconds;
+  db.run(
+    "INSERT INTO observations (id, memory_session_id, project, type, title, created_at, created_at_epoch) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    [
+      id,
+      "sess-1",
+      "test",
+      "discovery",
+      `obs-${id}`,
+      new Date(epoch * 1000).toISOString(),
+      epoch,
+    ],
+  );
+}
+
+function writeTranscript(dir: string, name: string, ageSeconds: number): void {
+  const path = join(dir, name);
+  writeFileSync(path, '{"role":"user"}\n');
+  const mtime = (Date.now() - ageSeconds * 1000) / 1000;
+  utimesSync(path, mtime, mtime);
+}
+
+describe("computePipelineHealth", () => {
+  let workDir: string;
+  let dbPath: string;
+  let watermarkPath: string;
+  let transcriptsDir: string;
+
+  beforeEach(() => {
+    workDir = createTempDir();
+    dbPath = join(workDir, "claude-mem.db");
+    watermarkPath = join(workDir, "watermark.json");
+    transcriptsDir = join(workDir, "projects");
+    mkdirSync(transcriptsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("healthy state — all layers aligned, no gaps", async () => {
+    const projDir = join(transcriptsDir, "-Users-test-project");
+    mkdirSync(projDir);
+    writeTranscript(projDir, "session-1.jsonl", 60); // 1min ago
+    writeTranscript(projDir, "session-2.jsonl", 3600); // 1hr ago
+
+    const db = createObservationsDb(dbPath);
+    insertObs(db, 1, 60);
+    insertObs(db, 2, 3600);
+    db.close();
+
+    writeFileSync(
+      watermarkPath,
+      JSON.stringify({
+        lastObservationId: 2,
+        lastSummaryId: 0,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    const inputs: PipelineHealthInputs = {
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 2,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    };
+
+    const health = await computePipelineHealth(inputs);
+
+    expect(health.activity.transcriptCount).toBe(2);
+    expect(health.captured.obsCount).toBe(2);
+    expect(health.captured.latestObsId).toBe(2);
+    expect(health.syncCursor.lastObsId).toBe(2);
+    expect(health.syncCursor.unsyncedCount).toBe(0);
+    expect(health.gaps).toHaveLength(0);
+    expect(health.verdict).toBe("healthy");
+  });
+
+  test("Gap A — activity exists but no obs captured (hooks broken)", async () => {
+    const projDir = join(transcriptsDir, "-Users-test-project");
+    mkdirSync(projDir);
+    writeTranscript(projDir, "session-1.jsonl", 60);
+    writeTranscript(projDir, "session-2.jsonl", 3600);
+    writeTranscript(projDir, "session-3.jsonl", 7200);
+
+    const db = createObservationsDb(dbPath);
+    db.close();
+
+    writeFileSync(
+      watermarkPath,
+      JSON.stringify({
+        lastObservationId: 0,
+        lastSummaryId: 0,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 0,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    });
+
+    expect(health.activity.transcriptCount).toBe(3);
+    expect(health.captured.obsCount).toBe(0);
+
+    const gapA = health.gaps.find((g) => g.layer === "A");
+    expect(gapA).toBeDefined();
+    expect(gapA?.severity).toBe("critical");
+    expect(gapA?.hint.toLowerCase()).toContain("claude-mem");
+    expect(health.verdict).toBe("critical");
+  });
+
+  test("Gap B — cursor lag (poller behind)", async () => {
+    const db = createObservationsDb(dbPath);
+    for (let i = 1; i <= 100; i++) insertObs(db, i, 60);
+    db.close();
+
+    writeFileSync(
+      watermarkPath,
+      JSON.stringify({
+        lastObservationId: 30,
+        lastSummaryId: 0,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 30,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "open",
+      },
+    });
+
+    expect(health.captured.latestObsId).toBe(100);
+    expect(health.syncCursor.lastObsId).toBe(30);
+    expect(health.syncCursor.unsyncedCount).toBe(70);
+
+    const gapB = health.gaps.find((g) => g.layer === "B");
+    expect(gapB).toBeDefined();
+    expect(gapB?.message).toContain("70");
+  });
+
+  test("Gap C — failed uploads", async () => {
+    const db = createObservationsDb(dbPath);
+    insertObs(db, 1, 60);
+    db.close();
+
+    writeFileSync(
+      watermarkPath,
+      JSON.stringify({
+        lastObservationId: 1,
+        lastSummaryId: 0,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 1,
+        failedCount: 5,
+        pendingCount: 2,
+        circuitState: "closed",
+      },
+    });
+
+    const gapC = health.gaps.find((g) => g.layer === "C");
+    expect(gapC).toBeDefined();
+    expect(gapC?.message).toContain("5");
+  });
+
+  test("graceful — claude-mem.db missing (claude-mem not installed)", async () => {
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath, // does not exist
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 0,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    });
+
+    expect(health.captured.dbExists).toBe(false);
+    expect(health.captured.obsCount).toBe(0);
+    // Should not throw — should report missing db with hint
+    const dbGap = health.gaps.find((g) =>
+      g.message.toLowerCase().includes("claude-mem.db"),
+    );
+    expect(dbGap).toBeDefined();
+  });
+
+  test("Gap A — db exists but query fails (schema drift)", async () => {
+    // Write a non-SQLite file at dbPath. Database can open it
+    // but the observations table query will throw.
+    writeFileSync(dbPath, "not a sqlite database");
+
+    writeFileSync(
+      watermarkPath,
+      JSON.stringify({
+        lastObservationId: 0,
+        lastSummaryId: 0,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 0,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    });
+
+    // Distinguish from missing-DB case: dbExists is true, but error is set
+    expect(health.captured.dbExists).toBe(true);
+    expect(health.captured.error).toBeDefined();
+
+    const gap = health.gaps.find((g) => g.layer === "A");
+    expect(gap).toBeDefined();
+    expect(gap?.message).toContain("query failed");
+    // Must NOT misdiagnose as "install claude-mem"
+    expect(gap?.hint).not.toContain("Install claude-mem");
+  });
+
+  test("graceful — corrupt watermark file", async () => {
+    const db = createObservationsDb(dbPath);
+    insertObs(db, 1, 60);
+    db.close();
+
+    writeFileSync(watermarkPath, "this-is-not-json");
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 0,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    });
+
+    expect(health.syncCursor.error).toBeDefined();
+    expect(health.syncCursor.lastObsId).toBe(0);
+    // Should NOT silently report Gap A "no obs captured" — error is surfaced
+    const gapA = health.gaps.find((g) => g.layer === "A");
+    expect(gapA).toBeUndefined();
+  });
+
+  test("graceful — watermark missing (fresh install)", async () => {
+    const db = createObservationsDb(dbPath);
+    insertObs(db, 1, 60);
+    db.close();
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath, // does not exist
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 0,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    });
+
+    expect(health.syncCursor.watermarkExists).toBe(false);
+    expect(health.syncCursor.lastObsId).toBe(0);
+    // Fresh install with 1 obs — should show as unsynced lag, not as a B-gap warning
+    expect(health.syncCursor.unsyncedCount).toBe(1);
+  });
+
+  test("transcript count respects windowHours filter", async () => {
+    const projDir = join(transcriptsDir, "-Users-test");
+    mkdirSync(projDir);
+    writeTranscript(projDir, "fresh.jsonl", 60); // 1min — in window
+    writeTranscript(projDir, "old.jsonl", 90000); // 25hr — out of window
+    writeTranscript(projDir, "ancient.jsonl", 7 * 86400); // 7d — out of window
+
+    const db = createObservationsDb(dbPath);
+    db.close();
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 0,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    });
+
+    expect(health.activity.transcriptCount).toBe(1);
+  });
+
+  test("captured count respects windowHours filter", async () => {
+    const db = createObservationsDb(dbPath);
+    insertObs(db, 1, 60); // in window
+    insertObs(db, 2, 90000); // out of window
+    db.close();
+
+    const health = await computePipelineHealth({
+      transcriptsDir,
+      dbPath,
+      watermarkPath,
+      windowHours: 24,
+      syncStats: {
+        syncedCount: 2,
+        failedCount: 0,
+        pendingCount: 0,
+        circuitState: "closed",
+      },
+    });
+
+    expect(health.captured.obsCount).toBe(1);
+    expect(health.captured.latestObsId).toBe(2); // MAX over all rows
+  });
+});
+
+describe("renderPipelineHealth", () => {
+  test("emits expected section headings and labels", () => {
+    const lines = renderPipelineHealth({
+      activity: { transcriptCount: 5, windowHours: 24 },
+      captured: {
+        obsCount: 5,
+        latestObsId: 100,
+        windowHours: 24,
+        dbPath: "/tmp/x.db",
+        dbExists: true,
+      },
+      syncCursor: { lastObsId: 100, unsyncedCount: 0, watermarkExists: true },
+      server: { lifetimeUsed: 1234 },
+      sync: { failedCount: 0, pendingCount: 0, circuitState: "closed" },
+      gaps: [],
+      verdict: "healthy",
+    });
+
+    const text = lines.join("\n");
+    expect(text).toContain("Pipeline Health");
+    expect(text).toContain("Activity (last 24h)");
+    expect(text).toContain("Captured (last 24h)");
+    expect(text).toContain("Sync cursor");
+    expect(text).toContain("Healthy");
+  });
+
+  test("escapes markdown control chars in dbPath (no injection)", () => {
+    const lines = renderPipelineHealth({
+      activity: { transcriptCount: 0, windowHours: 24 },
+      captured: {
+        obsCount: 0,
+        latestObsId: 0,
+        windowHours: 24,
+        dbPath: "/tmp/evil`# Healthy\n* fake",
+        dbExists: false,
+      },
+      syncCursor: { lastObsId: 0, unsyncedCount: 0, watermarkExists: true },
+      server: { lifetimeUsed: null },
+      sync: { failedCount: 0, pendingCount: 0, circuitState: "closed" },
+      gaps: [],
+      verdict: "critical",
+    });
+    const text = lines.join("\n");
+    // Backtick must be replaced (would otherwise close the inline-code wrap)
+    expect(text).not.toMatch(/`\/tmp\/evil`/);
+    // Newline inside path must be collapsed (otherwise it can break the inline-code wrap)
+    expect(text).not.toMatch(/evil.*Healthy\n\* fake/);
+    // The path must still be visible in some escaped form
+    expect(text).toContain("evil");
+    expect(text).toContain("Healthy");
+  });
+
+  test("renders error notes when a layer fails to read", () => {
+    const lines = renderPipelineHealth({
+      activity: { transcriptCount: 0, windowHours: 24, error: "EACCES" },
+      captured: {
+        obsCount: 0,
+        latestObsId: 0,
+        windowHours: 24,
+        dbPath: "/tmp/x.db",
+        dbExists: true,
+        error: "no such table: observations",
+      },
+      syncCursor: {
+        lastObsId: 0,
+        unsyncedCount: 0,
+        watermarkExists: true,
+        error: "Unexpected token",
+      },
+      server: { lifetimeUsed: null },
+      sync: { failedCount: 0, pendingCount: 0, circuitState: "closed" },
+      gaps: [],
+      verdict: "warning",
+    });
+    const text = lines.join("\n");
+    expect(text).toContain("EACCES");
+    expect(text).toContain("query failed");
+    expect(text).toContain("no such table");
+    expect(text).toContain("watermark unreadable");
+    expect(text).toContain("Unexpected token");
+  });
+
+  test("renders gap warnings with hints", () => {
+    const lines = renderPipelineHealth({
+      activity: { transcriptCount: 10, windowHours: 24 },
+      captured: {
+        obsCount: 0,
+        latestObsId: 0,
+        windowHours: 24,
+        dbPath: "/tmp/x.db",
+        dbExists: true,
+      },
+      syncCursor: { lastObsId: 0, unsyncedCount: 0, watermarkExists: true },
+      server: { lifetimeUsed: 0 },
+      sync: { failedCount: 0, pendingCount: 0, circuitState: "closed" },
+      gaps: [
+        {
+          layer: "A",
+          severity: "critical",
+          message: "10 transcripts modified but 0 observations captured",
+          hint: "Check claude-mem PostToolUse hook in ~/.claude/settings.json",
+        },
+      ],
+      verdict: "critical",
+    });
+
+    const text = lines.join("\n");
+    expect(text).toContain("Gap A");
+    expect(text).toContain("PostToolUse hook");
+  });
+});

--- a/src/mcp/handlers/pipeline-health.ts
+++ b/src/mcp/handlers/pipeline-health.ts
@@ -1,0 +1,486 @@
+/**
+ * Pipeline Health Diagnosis
+ *
+ * 4-layer matrix that distinguishes upstream-of-sync failures
+ * (Gap A: claude-mem hooks not capturing) from sync-side failures
+ * (Gap B: poller behind, Gap C: server rejects).
+ *
+ *   transcripts (~/.claude/projects/*.jsonl mtime)
+ *      ↓ Gap A — claude-mem PostToolUse hook not running
+ *   claude-mem.db observations COUNT(*)
+ *      ↓ Gap B — sync poller behind / circuit open
+ *   ~/.memforge/.sync-watermark.json lastObservationId
+ *      ↓ Gap C — server reject / quota exceeded / network
+ *   server quota.observations.used
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { Database } from "bun:sqlite";
+
+const SECONDS_PER_HOUR = 3600;
+const GAP_A_RATIO_THRESHOLD = 5; // captured << activity → partial hook failure
+const GAP_B_LAG_THRESHOLD = 50; // unsynced > 50 → poller behind
+
+type CircuitState = "closed" | "open" | "half-open";
+
+export interface SyncStatsInput {
+  syncedCount: number;
+  failedCount: number;
+  pendingCount: number;
+  circuitState: CircuitState;
+}
+
+export interface PipelineHealthInputs {
+  transcriptsDir: string;
+  dbPath: string;
+  watermarkPath: string;
+  windowHours: number;
+  syncStats: SyncStatsInput;
+  serverLifetimeUsed?: number | null;
+}
+
+export interface ActivityLayer {
+  transcriptCount: number;
+  windowHours: number;
+  error?: string;
+}
+
+export interface CapturedLayer {
+  obsCount: number;
+  latestObsId: number;
+  windowHours: number;
+  dbPath: string;
+  dbExists: boolean;
+  error?: string;
+}
+
+export interface SyncCursorLayer {
+  lastObsId: number;
+  unsyncedCount: number;
+  watermarkExists: boolean;
+  error?: string;
+}
+
+export interface ServerLayer {
+  lifetimeUsed: number | null;
+}
+
+export interface SyncHealth {
+  failedCount: number;
+  pendingCount: number;
+  circuitState: CircuitState;
+}
+
+export interface Gap {
+  layer: "A" | "B" | "C";
+  severity: "info" | "warning" | "critical";
+  message: string;
+  hint: string;
+}
+
+export type Verdict = "healthy" | "warning" | "critical";
+
+export interface PipelineHealth {
+  activity: ActivityLayer;
+  captured: CapturedLayer;
+  syncCursor: SyncCursorLayer;
+  server: ServerLayer;
+  sync: SyncHealth;
+  gaps: Gap[];
+  verdict: Verdict;
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+type TranscriptResult = { count: number; error?: string };
+
+function countTranscriptsInWindow(
+  rootDir: string,
+  windowSeconds: number,
+): TranscriptResult {
+  if (!existsSync(rootDir)) return { count: 0 };
+
+  const cutoff = Date.now() - windowSeconds * 1000;
+  let count = 0;
+
+  let projectDirs: string[];
+  try {
+    projectDirs = readdirSync(rootDir);
+  } catch (e) {
+    return {
+      count: 0,
+      error: `cannot read transcripts dir: ${errorMessage(e)}`,
+    };
+  }
+
+  for (const projectName of projectDirs) {
+    const projectPath = join(rootDir, projectName);
+    let projectStat;
+    try {
+      projectStat = statSync(projectPath);
+    } catch {
+      continue;
+    }
+    if (!projectStat.isDirectory()) continue;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(projectPath);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.endsWith(".jsonl")) continue;
+      try {
+        const stat = statSync(join(projectPath, entry));
+        if (stat.mtimeMs >= cutoff) count++;
+      } catch {
+        /* skip unreadable file */
+      }
+    }
+  }
+
+  return { count };
+}
+
+type DbResult =
+  | { kind: "missing" }
+  | { kind: "ok"; obsCount: number; latestObsId: number }
+  | { kind: "error"; message: string };
+
+function queryClaudeMemStats(dbPath: string, windowSeconds: number): DbResult {
+  if (!existsSync(dbPath)) return { kind: "missing" };
+
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const cutoffEpoch = Math.floor(Date.now() / 1000) - windowSeconds;
+
+    const countRow = db
+      .query(
+        "SELECT COUNT(*) as c FROM observations WHERE created_at_epoch > ?",
+      )
+      .get(cutoffEpoch) as { c: number } | null;
+
+    const maxRow = db.query("SELECT MAX(id) as m FROM observations").get() as {
+      m: number | null;
+    } | null;
+
+    return {
+      kind: "ok",
+      obsCount: countRow?.c ?? 0,
+      latestObsId: maxRow?.m ?? 0,
+    };
+  } catch (e) {
+    return { kind: "error", message: errorMessage(e) };
+  } finally {
+    if (db) {
+      try {
+        db.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+type WatermarkResult =
+  | { kind: "missing" }
+  | { kind: "ok"; lastObsId: number }
+  | { kind: "error"; message: string };
+
+function readWatermark(path: string): WatermarkResult {
+  if (!existsSync(path)) return { kind: "missing" };
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as { lastObservationId?: number };
+    return { kind: "ok", lastObsId: parsed.lastObservationId ?? 0 };
+  } catch (e) {
+    return { kind: "error", message: errorMessage(e) };
+  }
+}
+
+function detectGapA(
+  activity: ActivityLayer,
+  captured: CapturedLayer,
+): Gap | null {
+  if (!captured.dbExists) {
+    return {
+      layer: "A",
+      severity: "critical",
+      message: "claude-mem.db not found",
+      hint: "Install claude-mem plugin: /plugin marketplace add thedotmack/claude-mem",
+    };
+  }
+
+  if (captured.error) {
+    return {
+      layer: "A",
+      severity: "critical",
+      message: `claude-mem.db query failed: ${captured.error}`,
+      hint: "Schema may have drifted or DB is locked/corrupt. Check ~/.claude-mem/claude-mem.db integrity.",
+    };
+  }
+
+  if (activity.transcriptCount > 0 && captured.obsCount === 0) {
+    return {
+      layer: "A",
+      severity: "critical",
+      message: `${activity.transcriptCount} transcripts modified but 0 observations captured`,
+      hint: "Check claude-mem PostToolUse hook in ~/.claude/settings.json — observations are not being produced",
+    };
+  }
+
+  if (
+    captured.obsCount > 0 &&
+    activity.transcriptCount > captured.obsCount * GAP_A_RATIO_THRESHOLD
+  ) {
+    return {
+      layer: "A",
+      severity: "warning",
+      message: `${activity.transcriptCount} transcripts but only ${captured.obsCount} obs (ratio >${GAP_A_RATIO_THRESHOLD}x)`,
+      hint: "claude-mem may be partially failing — check ~/.claude-mem/logs/ for errors",
+    };
+  }
+
+  return null;
+}
+
+function detectGapB(syncCursor: SyncCursorLayer, sync: SyncHealth): Gap | null {
+  if (sync.circuitState === "open") {
+    return {
+      layer: "B",
+      severity: "critical",
+      message: `Sync circuit OPEN — ${syncCursor.unsyncedCount} obs waiting`,
+      hint: "Server unreachable. Check connectivity above; sync resumes after cooldown.",
+    };
+  }
+
+  if (syncCursor.unsyncedCount > GAP_B_LAG_THRESHOLD) {
+    return {
+      layer: "B",
+      severity: "warning",
+      message: `${syncCursor.unsyncedCount} obs unsynced (cursor lag > ${GAP_B_LAG_THRESHOLD})`,
+      hint: "Poller is behind. Check sync-poller logs (stderr); may catch up automatically.",
+    };
+  }
+
+  return null;
+}
+
+function detectGapC(sync: SyncHealth): Gap | null {
+  if (sync.failedCount > 0) {
+    return {
+      layer: "C",
+      severity: "warning",
+      message: `${sync.failedCount} obs failed to sync since process start`,
+      hint: "Server rejected uploads — check tier quota, API key validity, or server logs.",
+    };
+  }
+  return null;
+}
+
+function computeVerdict(gaps: Gap[]): Verdict {
+  if (gaps.some((g) => g.severity === "critical")) return "critical";
+  if (gaps.some((g) => g.severity === "warning")) return "warning";
+  return "healthy";
+}
+
+function buildActivityLayer(
+  result: TranscriptResult,
+  windowHours: number,
+): ActivityLayer {
+  return {
+    transcriptCount: result.count,
+    windowHours,
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+function buildCapturedLayer(
+  result: DbResult,
+  dbPath: string,
+  windowHours: number,
+): CapturedLayer {
+  if (result.kind === "ok") {
+    return {
+      obsCount: result.obsCount,
+      latestObsId: result.latestObsId,
+      windowHours,
+      dbPath,
+      dbExists: true,
+    };
+  }
+  if (result.kind === "missing") {
+    return {
+      obsCount: 0,
+      latestObsId: 0,
+      windowHours,
+      dbPath,
+      dbExists: false,
+    };
+  }
+  return {
+    obsCount: 0,
+    latestObsId: 0,
+    windowHours,
+    dbPath,
+    dbExists: true,
+    error: result.message,
+  };
+}
+
+function buildSyncCursorLayer(
+  result: WatermarkResult,
+  latestObsId: number,
+): SyncCursorLayer {
+  if (result.kind === "ok") {
+    return {
+      lastObsId: result.lastObsId,
+      unsyncedCount: Math.max(0, latestObsId - result.lastObsId),
+      watermarkExists: true,
+    };
+  }
+  if (result.kind === "missing") {
+    return {
+      lastObsId: 0,
+      unsyncedCount: latestObsId,
+      watermarkExists: false,
+    };
+  }
+  return {
+    lastObsId: 0,
+    unsyncedCount: latestObsId,
+    watermarkExists: true,
+    error: result.message,
+  };
+}
+
+export async function computePipelineHealth(
+  inputs: PipelineHealthInputs,
+): Promise<PipelineHealth> {
+  const windowSeconds = inputs.windowHours * SECONDS_PER_HOUR;
+
+  const transcripts = countTranscriptsInWindow(
+    inputs.transcriptsDir,
+    windowSeconds,
+  );
+  const dbStats = queryClaudeMemStats(inputs.dbPath, windowSeconds);
+  const watermark = readWatermark(inputs.watermarkPath);
+
+  const activity = buildActivityLayer(transcripts, inputs.windowHours);
+  const captured = buildCapturedLayer(
+    dbStats,
+    inputs.dbPath,
+    inputs.windowHours,
+  );
+  const syncCursor = buildSyncCursorLayer(watermark, captured.latestObsId);
+  const server: ServerLayer = {
+    lifetimeUsed: inputs.serverLifetimeUsed ?? null,
+  };
+  const sync: SyncHealth = {
+    failedCount: inputs.syncStats.failedCount,
+    pendingCount: inputs.syncStats.pendingCount,
+    circuitState: inputs.syncStats.circuitState,
+  };
+
+  const gaps: Gap[] = [];
+  const gapA = detectGapA(activity, captured);
+  if (gapA) gaps.push(gapA);
+  const gapB = detectGapB(syncCursor, sync);
+  if (gapB) gaps.push(gapB);
+  const gapC = detectGapC(sync);
+  if (gapC) gaps.push(gapC);
+
+  return {
+    activity,
+    captured,
+    syncCursor,
+    server,
+    sync,
+    gaps,
+    verdict: computeVerdict(gaps),
+  };
+}
+
+const SEVERITY_ICON: Record<Gap["severity"], string> = {
+  info: "ℹ",
+  warning: "⚠",
+  critical: "✗",
+};
+
+function inlineCode(s: string): string {
+  // Escape backticks and collapse newlines/control chars before wrapping
+  // in inline code — keeps markdown-renderer-injected paths/errors safe.
+  const safe = s.replace(/`/g, "ʼ").replace(/[\r\n\t]+/g, " ");
+  return "`" + safe + "`";
+}
+
+export function renderPipelineHealth(health: PipelineHealth): string[] {
+  const { activity, captured, syncCursor, server, sync, gaps, verdict } =
+    health;
+  const win = `last ${activity.windowHours}h`;
+  const lines: string[] = ["", "### Pipeline Health"];
+
+  lines.push(
+    `**Activity (${win}):** ${activity.transcriptCount.toLocaleString()} transcript file(s) modified`,
+  );
+  if (activity.error) {
+    lines.push(`   _note: ${inlineCode(activity.error)}_`);
+  }
+
+  if (captured.dbExists && !captured.error) {
+    lines.push(
+      `**Captured (${win}):** ${captured.obsCount.toLocaleString()} obs in claude-mem.db (latest id=${captured.latestObsId})`,
+    );
+  } else if (!captured.dbExists) {
+    lines.push(
+      `**Captured:** claude-mem.db not found at ${inlineCode(captured.dbPath)}`,
+    );
+  } else {
+    lines.push(`**Captured:** query failed (${inlineCode(captured.dbPath)})`);
+    lines.push(`   _note: ${inlineCode(captured.error!)}_`);
+  }
+
+  if (syncCursor.watermarkExists && !syncCursor.error) {
+    lines.push(
+      `**Sync cursor:** obs #${syncCursor.lastObsId} (${syncCursor.unsyncedCount.toLocaleString()} unsynced)`,
+    );
+  } else if (syncCursor.error) {
+    lines.push(`**Sync cursor:** watermark unreadable`);
+    lines.push(`   _note: ${inlineCode(syncCursor.error)}_`);
+  } else {
+    lines.push(
+      `**Sync cursor:** no watermark yet (${syncCursor.unsyncedCount} pending first sync)`,
+    );
+  }
+
+  const serverLine =
+    server.lifetimeUsed !== null
+      ? `**Server (lifetime):** ${server.lifetimeUsed.toLocaleString()} obs accepted`
+      : `**Server:** quota unknown`;
+  lines.push(serverLine);
+
+  lines.push(
+    `**Sync workers:** synced ok, ${sync.failedCount} failed, ${sync.pendingCount} pending, circuit=${sync.circuitState}`,
+  );
+
+  lines.push("");
+
+  if (verdict === "healthy") {
+    lines.push("✓ **Healthy** — all 4 layers aligned.");
+  } else {
+    for (const gap of gaps) {
+      lines.push(
+        `${SEVERITY_ICON[gap.severity]} **Gap ${gap.layer}** (${gap.severity}): ${gap.message}`,
+      );
+      lines.push(`   → ${gap.hint}`);
+    }
+  }
+
+  return lines;
+}

--- a/src/mcp/handlers/status-handler.ts
+++ b/src/mcp/handlers/status-handler.ts
@@ -4,6 +4,8 @@
  * Diagnostic tool for checking MemForge client configuration and connectivity.
  */
 
+import { homedir } from "os";
+import { join } from "path";
 import type { ToolDefinition } from "../types";
 import {
   getConfigSource,
@@ -17,6 +19,46 @@ import {
   wrapSuccess,
 } from "../api-client";
 import { syncPoller } from "../mcp-server";
+import {
+  computePipelineHealth,
+  renderPipelineHealth,
+  type SyncStatsInput,
+} from "./pipeline-health";
+
+const TRANSCRIPTS_DIR = join(homedir(), ".claude", "projects");
+const CLAUDE_MEM_DB = join(homedir(), ".claude-mem", "claude-mem.db");
+const SYNC_WATERMARK = join(homedir(), ".memforge", ".sync-watermark.json");
+const PIPELINE_WINDOW_HOURS = 24;
+
+const ZERO_SYNC_STATS: SyncStatsInput = {
+  syncedCount: 0,
+  failedCount: 0,
+  pendingCount: 0,
+  circuitState: "closed",
+};
+
+async function appendPipelineHealth(
+  lines: string[],
+  syncStats: SyncStatsInput,
+): Promise<void> {
+  try {
+    const quota = getQuota();
+    const health = await computePipelineHealth({
+      transcriptsDir: TRANSCRIPTS_DIR,
+      dbPath: CLAUDE_MEM_DB,
+      watermarkPath: SYNC_WATERMARK,
+      windowHours: PIPELINE_WINDOW_HOURS,
+      syncStats,
+      serverLifetimeUsed: quota?.observations.used ?? null,
+    });
+    lines.push(...renderPipelineHealth(health));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const safe =
+      "`" + message.replace(/`/g, "ʼ").replace(/[\r\n]+/g, " ") + "`";
+    lines.push(`\n_Pipeline health check skipped: ${safe}_`);
+  }
+}
 
 /**
  * Mask API key for display.
@@ -53,6 +95,9 @@ export const memStatus: ToolDefinition = {
       lines.push("**Status:** Not configured");
       lines.push("");
       lines.push('Run `bun run setup "your-api-key"` to configure.');
+      // Pipeline Health is local-only — still useful when remote is unconfigured
+      // so users can verify claude-mem is producing observations locally.
+      await appendPipelineHealth(lines, ZERO_SYNC_STATS);
       return wrapSuccess(lines.join("\n"));
     }
 
@@ -110,12 +155,21 @@ export const memStatus: ToolDefinition = {
         if (quota) {
           const obsLimit = quota.observations.limit;
           const obsUsed = quota.observations.used ?? 0;
-          const isUnlimited = obsLimit === null || obsLimit === undefined || obsLimit === 0;
-          const limitStr = isUnlimited ? "Unlimited" : obsLimit.toLocaleString();
+          const isUnlimited =
+            obsLimit === null || obsLimit === undefined || obsLimit === 0;
+          const limitStr = isUnlimited
+            ? "Unlimited"
+            : obsLimit.toLocaleString();
           const pct = isUnlimited ? 0 : Math.round((obsUsed / obsLimit) * 100);
           const synthLimit = quota.synthesis.limit_per_day;
-          const synthStr = synthLimit === null || synthLimit === undefined ? "Unlimited" : `${synthLimit}`;
-          const rateStr = quota.rate_limit === 0 || quota.rate_limit === null ? "No limit" : `${quota.rate_limit} req/min`;
+          const synthStr =
+            synthLimit === null || synthLimit === undefined
+              ? "Unlimited"
+              : `${synthLimit}`;
+          const rateStr =
+            quota.rate_limit === 0 || quota.rate_limit === null
+              ? "No limit"
+              : `${quota.rate_limit} req/min`;
 
           lines.push("");
           lines.push("### Quota");
@@ -123,9 +177,7 @@ export const memStatus: ToolDefinition = {
             `**Observations:** ${obsUsed.toLocaleString()} / ${limitStr}${isUnlimited ? "" : ` (${pct}%)`}`,
           );
           lines.push(`**Synthesis:** ${synthStr}/day`);
-          lines.push(
-            `**Search Modes:** ${quota.search_modes.join(", ")}`,
-          );
+          lines.push(`**Search Modes:** ${quota.search_modes.join(", ")}`);
           lines.push(`**Rate Limit:** ${rateStr}`);
 
           if (!isUnlimited && pct >= 90) {
@@ -156,8 +208,9 @@ export const memStatus: ToolDefinition = {
       clearTimeout(authTimeoutId);
     }
 
-    // Sync stats
+    // Sync stats — capture for pipeline-health input regardless of branch
     lines.push("");
+    let pipelineSyncStats: SyncStatsInput = ZERO_SYNC_STATS;
     if (syncPoller?.isActive()) {
       const stats = syncPoller.getStats();
       lines.push(
@@ -166,11 +219,21 @@ export const memStatus: ToolDefinition = {
       if (stats.circuitState !== "closed") {
         lines.push(`**Circuit:** ${stats.circuitState}`);
       }
+      pipelineSyncStats = {
+        syncedCount: stats.syncedCount,
+        failedCount: stats.failedCount,
+        pendingCount: stats.pendingCount,
+        circuitState: stats.circuitState,
+      };
     } else if (syncPoller) {
       lines.push("**Sync:** starting...");
     } else {
       lines.push("**Sync:** not running");
     }
+
+    // Pipeline Health — runs unconditionally so Gap A (claude-mem.db missing)
+    // is visible even when poller is inactive. See handlers/pipeline-health.ts.
+    await appendPipelineHealth(lines, pipelineSyncStats);
 
     return wrapSuccess(lines.join("\n"));
   },


### PR DESCRIPTION
## Summary

- Adds a **Pipeline Health** section to `mem_status` that surfaces upstream-of-sync failures (Gap A) which the existing connectivity/auth/sync stats cannot see — fixes the silent-failure mode where claude-mem hooks stop producing observations but `mem_status` still reports GREEN
- Reads four layers (transcripts → claude-mem.db → watermark → server quota) using sources that already exist; no new server endpoint required
- Detects three gap shapes: Gap A (claude-mem hooks broken or db missing/corrupt), Gap B (poller behind / circuit open), Gap C (server rejects)
- Pipeline Health runs **unconditionally** in `mem_status` — including when sync is unconfigured or `syncPoller` is inactive; otherwise the most important Gap A case ("claude-mem.db not found → install plugin") would never reach the user

## Why this matters

Reported observation: several clients show observation counts on the MemForge UI that are far lower than their actual work activity. The current `mem_status` only measures the sync transport — it has no visibility into whether observations are being produced upstream, so it reports healthy even when no obs are being captured at all. See #58 for the full problem analysis.

## Implementation notes

- New module `src/mcp/handlers/pipeline-health.ts` — pure readers, discriminated unions per layer so "missing" and "error" states are not collapsed (a corrupt DB is not the same as an uninstalled DB)
- Markdown injection-safe rendering: paths and error messages wrapped in inline code with backtick + newline escaping (defends against unusual homedir/error contents)
- Gap C is best-effort: uses `failedCount`/`circuitState`/`pendingCount` from the in-memory poller (since-process-start signal). Server-side time-windowed obs count would require a new endpoint — explicitly out of scope for this PR (#58)
- `computePipelineHealth` factored into `buildActivityLayer` / `buildCapturedLayer` / `buildSyncCursorLayer` helpers (each <30 LOC); main function is ~30 LOC; module total 486 LOC after formatter

## Test plan

- [x] `bun test src/mcp/__tests__/` — 80/80 pass
- [x] Live render against real `~/.claude-mem/claude-mem.db` and `~/.memforge/.sync-watermark.json` — healthy state renders correctly with this user's actual numbers
- [x] Live render with `dbPath` pointed at a nonexistent file — Gap A surfaces with critical severity and "install claude-mem" hint
- [x] Markdown injection probe (`dbPath` containing backtick + newline + `# Healthy` markdown header) — escaped, cannot inject a fake "Healthy" verdict
- [x] Schema drift case (db file exists but is not SQLite / has no `observations` table) — surfaces as Gap A "query failed", **not** as the misleading "install claude-mem" hint
- [x] Corrupt watermark case (file exists, JSON parse fails) — surfaces in `syncCursor.error` and as a `_note:` line, does not silently zero the cursor
- [x] `bun tsc --noEmit` — no new errors in modified files (1 pre-existing error in `mcp-server.ts` unrelated to this change)
- [ ] Reviewer to confirm the rendered output reads correctly in their MCP client (markdown rendering varies)

## Reviewer focus

- Placement check: confirm `appendPipelineHealth` is called in **both** the "remote not configured" early-return path and the main path. Unit tests cover the function in isolation; only an integration read catches placement bugs.
- Gap detection rules in `detectGapA`/`detectGapB`/`detectGapC` — thresholds are heuristic (`GAP_A_RATIO_THRESHOLD = 5`, `GAP_B_LAG_THRESHOLD = 50`); please flag if these are wrong for typical workloads
- Schema drift handling: do you agree that DB-exists-but-query-failed deserves its own Gap A variant rather than being reported as "claude-mem not installed"?

Refs #58