### PR TITLE
feat(tools): add mem_set_status — observation lifecycle status (v1.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ Restart to load the plugin. Verify with `mem_status` tool — should show connec
 
 ### Memory Curation
 
-| Tool                 | Purpose                                        |
-| -------------------- | ---------------------------------------------- |
-| `mem_pin`            | Pin observation — protect from decay/archival  |
-| `mem_set_importance` | Override importance score (0-1)                |
-| `mem_set_event_date` | Set temporal event date for time-based queries |
-| `mem_contradict`     | Mark stale + create correction observation     |
-| `mem_drift_check`    | Find oldest unverified observations            |
+| Tool                 | Purpose                                                              |
+| -------------------- | -------------------------------------------------------------------- |
+| `mem_pin`            | Pin observation — protect from decay/archival                        |
+| `mem_set_importance` | Override importance score (0-1)                                      |
+| `mem_set_event_date` | Set temporal event date for time-based queries                       |
+| `mem_set_status`     | Set lifecycle status (active/deprecated/superseded/applied/archived) |
+| `mem_contradict`     | Mark stale + create correction observation                           |
+| `mem_drift_check`    | Find oldest unverified observations                                  |
 
 ### Knowledge Graph
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/src/mcp/handlers/index.ts
+++ b/src/mcp/handlers/index.ts
@@ -68,6 +68,7 @@ export {
   memPin,
   memSetImportance,
   memSetEventDate,
+  memSetStatus,
   memContradict,
   memDriftCheck,
 } from "./metadata-handlers";

--- a/src/mcp/handlers/metadata-handlers.ts
+++ b/src/mcp/handlers/metadata-handlers.ts
@@ -1,8 +1,8 @@
 /**
  * MCP Metadata Handlers (#42)
  *
- * 5 tools for observation metadata management:
- * pin, set_importance, set_event_date, contradict, drift_check.
+ * 6 tools for observation metadata management:
+ * pin, set_importance, set_event_date, set_status, contradict, drift_check.
  */
 
 import type { ToolDefinition } from "../types";
@@ -197,6 +197,61 @@ export const memSetEventDate: ToolDefinition = {
   },
 };
 
+/** mem_set_status tool definition */
+export const memSetStatus: ToolDefinition = {
+  name: "mem_set_status",
+  description:
+    "Set the lifecycle status of an observation. " +
+    "Use 'deprecated' when knowledge is outdated but still worth keeping for history. " +
+    "Use 'superseded' when a newer observation replaces this one. " +
+    "Use 'applied' when an action item or recommendation has been acted on. " +
+    "Use 'archived' to remove from default search without deleting. " +
+    "Default status is 'active'. Default search hides 'deprecated' and 'archived'.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      observation_id: {
+        type: "number",
+        description: "Observation ID to update (required)",
+      },
+      status: {
+        type: "string",
+        enum: ["active", "deprecated", "superseded", "applied", "archived"],
+        description:
+          "Lifecycle status: active | deprecated | superseded | applied | archived",
+      },
+    },
+    required: ["observation_id", "status"],
+  },
+  handler: async (args) => {
+    try {
+      const id = Number(args.observation_id);
+      if (!Number.isInteger(id) || id < 1) {
+        return wrapError(new Error("Invalid observation_id."));
+      }
+      const status = args.status as string;
+
+      await patchRemoteAPI(`/api/observations/${id}`, { status });
+
+      return wrapSuccess(
+        `Observation #${id} status set to '${status}'.` +
+          (status === "archived" || status === "deprecated"
+            ? " It will be hidden from default search results."
+            : ""),
+      );
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("404"))
+        return wrapSuccess(`Observation #${args.observation_id} not found.`);
+      if (msg.includes("400") || msg.includes("Invalid status"))
+        return wrapSuccess(
+          `Invalid status '${args.status}'. Must be one of: active, deprecated, superseded, applied, archived.`,
+        );
+      return wrapError(error);
+    }
+  },
+};
+
 /** mem_contradict tool definition */
 export const memContradict: ToolDefinition = {
   name: "mem_contradict",
@@ -318,6 +373,7 @@ export const metadataHandlers: ToolDefinition[] = [
   memPin,
   memSetImportance,
   memSetEventDate,
+  memSetStatus,
   memContradict,
   memDriftCheck,
 ];


### PR DESCRIPTION
## Summary

- Adds `mem_set_status` MCP tool so Claude Code sessions can set observation lifecycle status: `active | deprecated | superseded | applied | archived`
- Server-side implementation shipped in memforge v1.12.0 (PR #547) but the client plugin was never updated — Claude Code couldn't call it
- Tool description guides when to use each status; `deprecated`/`archived` responses note they're hidden from default search (FR-010)
- Bumps plugin to v2.6.0

## Test plan

- [ ] `mem_set_status(observation_id: <id>, status: "deprecated")` → returns success message with visibility note
- [ ] `mem_set_status(observation_id: <id>, status: "active")` → restores to active, no visibility note
- [ ] Invalid status → graceful error message (not raw exception)
- [ ] Non-existent ID → "Observation not found" response
- [ ] Tool appears in Claude Code MCP tool list after `/mcp restart`