### PR TITLE
feat(mcp): add 'database' arg on read tools for cross-DB read allowlist (#61)

### DIFF
--- a/src/mcp/handlers/observation-handlers.ts
+++ b/src/mcp/handlers/observation-handlers.ts
@@ -108,17 +108,27 @@ export const memTimeline: ToolDefinition = {
         type: "string",
         description: "Filter by project name",
       },
+      database: {
+        type: "string",
+        description:
+          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
+          "Defaults to the primary database. See memforge #574 for the cross-DB read allowlist model.",
+      },
     },
   },
   handler: async (args) => {
     try {
-      const params = {
+      const params: Record<string, unknown> = {
         anchor: args.anchor,
         query: args.query,
         depth_before: args.depth_before || 5,
         depth_after: args.depth_after || 5,
         project: args.project,
       };
+      // Cross-DB read (memforge #574): forward as ?db= when set.
+      if (typeof args.database === "string" && args.database) {
+        params.db = args.database;
+      }
 
       const data = (await callRemoteAPI(
         "/api/timeline",

--- a/src/mcp/handlers/search-handlers.ts
+++ b/src/mcp/handlers/search-handlers.ts
@@ -176,6 +176,13 @@ export const memHybridSearch: ToolDefinition = {
         description:
           "Include observations shared with you by other users (default: false)",
       },
+      database: {
+        type: "string",
+        description:
+          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
+          "Defaults to the primary database. Writes (sync) always go to primary regardless of this. " +
+          "See memforge #574 for the cross-DB read allowlist model.",
+      },
     },
     required: ["q"],
   },
@@ -190,9 +197,18 @@ export const memHybridSearch: ToolDefinition = {
       dateEnd: args.dateEnd,
       tz: args.tz,
       include_shared: args.include_shared,
+      // Cross-DB read (memforge #574): forward as ?db= when set.
+      ...(typeof args.database === "string" && args.database
+        ? { db: args.database }
+        : {}),
     });
     if (note && result.content[0]?.type === "text") {
-      return { ...result, content: [{ ...result.content[0], text: note + result.content[0].text }] };
+      return {
+        ...result,
+        content: [
+          { ...result.content[0], text: note + result.content[0].text },
+        ],
+      };
     }
     return result;
   },
@@ -239,6 +255,13 @@ export const memVectorSearch: ToolDefinition = {
         description:
           "Include observations shared with you by other users (default: false)",
       },
+      database: {
+        type: "string",
+        description:
+          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
+          "Defaults to the primary database. Writes (sync) always go to primary regardless of this. " +
+          "See memforge #574 for the cross-DB read allowlist model.",
+      },
     },
     required: ["q"],
   },
@@ -252,9 +275,18 @@ export const memVectorSearch: ToolDefinition = {
       dateEnd: args.dateEnd,
       tz: args.tz,
       include_shared: args.include_shared,
+      // Cross-DB read (memforge #574): forward as ?db= when set.
+      ...(typeof args.database === "string" && args.database
+        ? { db: args.database }
+        : {}),
     });
     if (note && result.content[0]?.type === "text") {
-      return { ...result, content: [{ ...result.content[0], text: note + result.content[0].text }] };
+      return {
+        ...result,
+        content: [
+          { ...result.content[0], text: note + result.content[0].text },
+        ],
+      };
     }
     return result;
   },
@@ -310,6 +342,13 @@ export const memSearch: ToolDefinition = {
         description:
           "Include observations shared with you by other users (default: false)",
       },
+      database: {
+        type: "string",
+        description:
+          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
+          "Defaults to the primary database. Writes (sync) always go to primary regardless of this. " +
+          "See memforge #574 for the cross-DB read allowlist model.",
+      },
     },
     required: ["query"],
   },
@@ -324,6 +363,10 @@ export const memSearch: ToolDefinition = {
       dateEnd: args.dateEnd,
       tz: args.tz,
       include_shared: args.include_shared,
+      // Cross-DB read (memforge #574): forward as ?db= when set.
+      ...(typeof args.database === "string" && args.database
+        ? { db: args.database }
+        : {}),
     });
   },
 };


### PR DESCRIPTION
## Summary

Closes #61. Adds optional `database` arg to four MCP read tools so users with the memforge cross-DB read allowlist (memforge #574, available in v1.13.5+) can query secondary tenant databases via MCP.

Server-side enforcement was fully shipped today in memforge v1.13.5 (chokepoint at `api-proxy-slim.ts` enforces 12-route allowlist + 403 on disallowed DB + per-DB cache isolation + audit routing to primary with `effective_db` detail). This PR closes the user-facing MCP gap that prevented Claude Code users from leveraging that capability.

## Changes

Four MCP tool definitions in `src/mcp/handlers/`:

| Tool | File:line | Server route |
|---|---|---|
| `mem_search` | search-handlers.ts:265 | `GET /api/search?db=<X>` |
| `mem_hybrid_search` | search-handlers.ts:135 | `GET /api/hybrid?db=<X>` |
| `mem_vector_search` | search-handlers.ts:203 | `GET /api/vector?db=<X>` |
| `mem_timeline` | observation-handlers.ts:82 | `GET /api/timeline?db=<X>` |

For each, the change is:

1. Add `database` to `inputSchema.properties` (optional string with description).
2. In the handler, forward `args.database` as `db: <value>` when set — type-guarded against the `Record<string, unknown>` args type:
   ```ts
   ...(typeof args.database === "string" && args.database
     ? { db: args.database }
     : {}),
   ```

No changes to `api-client.ts` — its `URLSearchParams` loop at line 367-372 already forwards every kv pair to the server.

## Behavior

- **Backwards-compatible**: servers running memforge < v1.13.5 silently ignore `?db=` (no chokepoint code path); existing callers without `database` get current behavior.
- **403 DB_NOT_ALLOWED**: when the caller passes a DB not in the key's `readDatabases` allowlist, the server returns 403 with `code: \"FORBIDDEN\", detail: \"DB_NOT_ALLOWED\"`. The MCP tool surfaces this as a normal error.
- **Audit trail intact**: server always writes audit rows to the primary tenant's `audit_log`; cross-DB reads are stamped with `details.effective_db = \"<requested>\"`.

## Excluded from this PR

`mem_get_observations` uses `POST /api/observations/batch` which is NOT in the server's allowlist (allowlist is GET-only by design). Adding `?db=` there would be silently dropped server-side. This needs a server-side change first (either add a batch GET route, or document the limitation). Tracked separately.

## Test plan

- [x] `bunx tsc --noEmit`: no new TypeScript errors. Pre-existing `mcp-server.ts` error on main is unchanged (1 error on baseline, 1 after patch).
- [x] Grep verification: 4 tool definitions now include the `database` field in inputSchema (3 in search-handlers.ts + 1 in observation-handlers.ts).
- [ ] Manual E2E after release — installed plugin v2.6.x, mem_search with `database: \"systeminfra.db\"` returns secondary tenant's data (verified at the API level today on memforge v1.13.5 production).

## References

- memforge #574 (closed) — cross-DB read allowlist fully shipped to v1.13.5
- memforge PR #575 (Wave 1 — schema/types/Zod/server-side MCP)
- memforge PR #576 (Wave 2 — chokepoint enforcement)
- memforge PR #580 (Wave 2b — audit routing with effective_db)
- This issue: #61