### PR TITLE
fix(mcp): add 'database' to validation schemas — v2.6.0 stripped the arg

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -49,6 +49,14 @@ const schemas: Record<string, z.ZodType> = {
     tz: tzField,
     offset: z.coerce.number().int().min(0).optional(),
     include_shared: z.boolean().optional(),
+    // Cross-DB read allowlist (memforge #574). Same charset as server-side
+    // Zod regex for `database` on POST /api/admin/keys.
+    database: z
+      .string()
+      .min(1)
+      .max(128)
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+      .optional(),
   }),
 
   mem_vector_search: z.object({
@@ -59,6 +67,13 @@ const schemas: Record<string, z.ZodType> = {
     tz: tzField,
     offset: z.coerce.number().int().min(0).optional(),
     include_shared: z.boolean().optional(),
+    // Cross-DB read allowlist (memforge #574).
+    database: z
+      .string()
+      .min(1)
+      .max(128)
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+      .optional(),
   }),
 
   mem_search: z.object({
@@ -71,6 +86,13 @@ const schemas: Record<string, z.ZodType> = {
     tz: tzField,
     offset: z.coerce.number().int().min(0).optional(),
     include_shared: z.boolean().optional(),
+    // Cross-DB read allowlist (memforge #574).
+    database: z
+      .string()
+      .min(1)
+      .max(128)
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+      .optional(),
   }),
 
   mem_semantic_get: z.object({
@@ -88,6 +110,13 @@ const schemas: Record<string, z.ZodType> = {
       depth_before: z.coerce.number().int().min(0).max(50).optional(),
       depth_after: z.coerce.number().int().min(0).max(50).optional(),
       project: z.string().max(200).optional(),
+      // Cross-DB read allowlist (memforge #574).
+      database: z
+        .string()
+        .min(1)
+        .max(128)
+        .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+        .optional(),
     })
     .refine(
       (data) =>


### PR DESCRIPTION
## Summary

v2.6.0 added `database` to the tool `inputSchema` + handler forwarding, but missed the **Zod validation layer** at `src/mcp/validation.ts`. The mcp-server calls `validateToolInput()` BEFORE the handler, and Zod's default `strip` mode silently dropped `database` because the field wasn't in those validation schemas.

Result: v2.6.0 announced the schema correctly to clients, accepted the arg in tool calls, but the URL the plugin sent to the server omitted `db=`. Cross-DB read silently returned primary data.

## Bug reproduction (v2.6.0)

```
mem_search({ query: "memforge", database: "systeminfra.db" })
→ first id: 242315  (itarun primary — WRONG, should be 9240 from systeminfra.db)
```

Captured by tracing the actual URL the plugin sends:
```
[DBG-URL] https://memclaude.thaicloud.ai/api/search?q=memforge&limit=2
                                                                    ^^^^^ no &db=
```

And args reaching the handler:
```
[DBG-ARGS] {"query":"memforge","limit":2}
                                          ^^^ database stripped by Zod
```

## Fix (this PR)

Add `database` to 4 read-tool Zod schemas in `src/mcp/validation.ts`:
- `mem_search`
- `mem_hybrid_search`
- `mem_vector_search`
- `mem_timeline`

Each entry uses the same regex as memforge server's `POST /api/admin/keys` validation (`/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/`, min 1, max 128) — defense in depth, invalid DB names get rejected client-side before the request leaves.

## Verification

After patching `validation.ts` and re-running the MCP smoke:

```
mem_search({ query: "memforge", database: "systeminfra.db" })
→ first id: 9240  (systeminfra.db schema — CORRECT)
```

Side-by-side with direct curl (which always worked):
```
curl -H "X-API-Key: $KEY" ".../api/search?q=memforge & db=systeminfra.db"
→ first id: 9240  ✓
```

## Files

| Status | File | Δ |
|---|---|---|
| MOD | `src/mcp/validation.ts` | +32 — 4 schemas + 1 helper regex pattern |
| MOD | `package.json` | 2.6.0 → 2.6.1 |
| MOD | `.claude-plugin/plugin.json` | 2.6.0 → 2.6.1 |
| MOD | `.claude-plugin/marketplace.json` | 2.6.0 → 2.6.1 |

## Test plan

- [x] `bunx tsc --noEmit`: no new TypeScript errors. Pre-existing mcp-server.ts SDK type mismatch unchanged.
- [x] MCP smoke: `mem_search({query, database})` returns secondary-schema data (verified end-to-end against memforge v1.13.5 production).
- [x] Direct curl baseline preserved (always worked, ?db= reaches server).
- [ ] After merge: tag v2.6.1, GitHub Release, claude plugin update.

## Hindsight

The plan-checker run on this PR's parent ([memforge #574 Wave 2](https://github.com/pitimon/memforge/pull/576)) caught analogous server-side issues, but I didn't run an equivalent check on the c-memforge handler edits in PR #62. Should have done an E2E smoke before tagging v2.6.0 — the schema-strip-by-default behavior is exactly the kind of thing a quick `bun -e` MCP call would have caught.

Refs #61, this is a hotfix for #62.