### PR TITLE
feat(mcp): widen database arg for memforge #574 Wave 4 multi-DB syntax

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/src/mcp/handlers/observation-handlers.ts
+++ b/src/mcp/handlers/observation-handlers.ts
@@ -111,8 +111,9 @@ export const memTimeline: ToolDefinition = {
       database: {
         type: "string",
         description:
-          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
-          "Defaults to the primary database. See memforge #574 for the cross-DB read allowlist model.",
+          "Optional: read from a different single database in the API key's `readDatabases` allowlist. " +
+          "Timeline anchors are per-schema row IDs, so multi-DB syntax (`*` or `a,b`) is rejected here with HTTP 400 `SINGLE_DB_ONLY` — pass a single name. " +
+          "Defaults to primary. See memforge #574.",
       },
     },
   },

--- a/src/mcp/handlers/search-handlers.ts
+++ b/src/mcp/handlers/search-handlers.ts
@@ -179,9 +179,10 @@ export const memHybridSearch: ToolDefinition = {
       database: {
         type: "string",
         description:
-          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
-          "Defaults to the primary database. Writes (sync) always go to primary regardless of this. " +
-          "See memforge #574 for the cross-DB read allowlist model.",
+          "Optional: read from secondary database(s) listed in the API key's `readDatabases` allowlist. " +
+          "Accepts a single name (`systeminfra.db`), comma-separated list (`a,b,c` up to 8), or `*` for the entire allowlist. " +
+          "Multi-DB requests (csv or `*`) fan out server-side and merge results by RRF; each merged item carries a `database` field naming its source. " +
+          "Defaults to primary; writes always go to primary regardless. See memforge #574.",
       },
     },
     required: ["q"],
@@ -258,9 +259,10 @@ export const memVectorSearch: ToolDefinition = {
       database: {
         type: "string",
         description:
-          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
-          "Defaults to the primary database. Writes (sync) always go to primary regardless of this. " +
-          "See memforge #574 for the cross-DB read allowlist model.",
+          "Optional: read from secondary database(s) listed in the API key's `readDatabases` allowlist. " +
+          "Accepts a single name (`systeminfra.db`), comma-separated list (`a,b,c` up to 8), or `*` for the entire allowlist. " +
+          "Multi-DB requests (csv or `*`) fan out server-side and merge results by RRF; each merged item carries a `database` field naming its source. " +
+          "Defaults to primary; writes always go to primary regardless. See memforge #574.",
       },
     },
     required: ["q"],
@@ -345,9 +347,10 @@ export const memSearch: ToolDefinition = {
       database: {
         type: "string",
         description:
-          "Optional: read from a different database listed in the API key's `readDatabases` allowlist. " +
-          "Defaults to the primary database. Writes (sync) always go to primary regardless of this. " +
-          "See memforge #574 for the cross-DB read allowlist model.",
+          "Optional: read from secondary database(s) listed in the API key's `readDatabases` allowlist. " +
+          "Accepts a single name (`systeminfra.db`), comma-separated list (`a,b,c` up to 8), or `*` for the entire allowlist. " +
+          "Multi-DB requests (csv or `*`) fan out server-side and merge results by RRF; each merged item carries a `database` field naming its source. " +
+          "Defaults to primary; writes always go to primary regardless. See memforge #574.",
       },
     },
     required: ["query"],

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -51,11 +51,17 @@ const schemas: Record<string, z.ZodType> = {
     include_shared: z.boolean().optional(),
     // Cross-DB read allowlist (memforge #574). Same charset as server-side
     // Zod regex for `database` on POST /api/admin/keys.
+    // Wave 4 (memforge v1.14.0): widened to accept "*" (entire allowlist)
+    // and "a,b,c" (explicit csv up to 8). Single name (v1.13.5 contract)
+    // still passes. Server-side parseDbParam validates each token; this
+    // client regex is a loose pre-check that matches the union.
     database: z
       .string()
       .min(1)
-      .max(128)
-      .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+      .max(512)
+      .regex(
+        /^(\*|[a-zA-Z0-9][a-zA-Z0-9_.-]*(\s*,\s*[a-zA-Z0-9][a-zA-Z0-9_.-]*){0,7})$/,
+      )
       .optional(),
   }),
 
@@ -68,11 +74,17 @@ const schemas: Record<string, z.ZodType> = {
     offset: z.coerce.number().int().min(0).optional(),
     include_shared: z.boolean().optional(),
     // Cross-DB read allowlist (memforge #574).
+    // Wave 4 (memforge v1.14.0): widened to accept "*" (entire allowlist)
+    // and "a,b,c" (explicit csv up to 8). Single name (v1.13.5 contract)
+    // still passes. Server-side parseDbParam validates each token; this
+    // client regex is a loose pre-check that matches the union.
     database: z
       .string()
       .min(1)
-      .max(128)
-      .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+      .max(512)
+      .regex(
+        /^(\*|[a-zA-Z0-9][a-zA-Z0-9_.-]*(\s*,\s*[a-zA-Z0-9][a-zA-Z0-9_.-]*){0,7})$/,
+      )
       .optional(),
   }),
 
@@ -87,11 +99,17 @@ const schemas: Record<string, z.ZodType> = {
     offset: z.coerce.number().int().min(0).optional(),
     include_shared: z.boolean().optional(),
     // Cross-DB read allowlist (memforge #574).
+    // Wave 4 (memforge v1.14.0): widened to accept "*" (entire allowlist)
+    // and "a,b,c" (explicit csv up to 8). Single name (v1.13.5 contract)
+    // still passes. Server-side parseDbParam validates each token; this
+    // client regex is a loose pre-check that matches the union.
     database: z
       .string()
       .min(1)
-      .max(128)
-      .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/)
+      .max(512)
+      .regex(
+        /^(\*|[a-zA-Z0-9][a-zA-Z0-9_.-]*(\s*,\s*[a-zA-Z0-9][a-zA-Z0-9_.-]*){0,7})$/,
+      )
       .optional(),
   }),
 


### PR DESCRIPTION
Server v1.14.0 ships ?db=* / ?db=csv. v2.6.1 Zod regex rejected both client-side. Widened regex on 3 multi-DB tools (mem_search, mem_hybrid_search, mem_vector_search); mem_timeline stays single-name (server returns 400 SINGLE_DB_ONLY on multi). Backwards-compat: single-name form unchanged.

Refs pitimon/memforge#574