### PR TITLE
chore(release): 2.8.0 — local JSONL token-usage push

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Minor release: bundles #65 (local JSONL token-usage push, memforge ADR-003).

- Version bump 2.7.0 → 2.8.0 across all 3 files (package.json, plugin.json, marketplace.json)
- Feature: dependency-free JSONL parser + throttled sync-poller push to `POST /api/usage/tokens` — no `ccusage` install needed on client machines
- Server dependency: memforge v1.16.0 (live in production)

Verified byte-exact vs `ccusage --timezone UTC` on real transcripts; e2e confirmed against production.