### PR TITLE
feat(usage): widen JSONL scan window 7 → 30 days (env-overridable)

### DIFF
--- a/src/sync/sync-poller.ts
+++ b/src/sync/sync-poller.ts
@@ -81,7 +81,16 @@ const CIRCUIT_COOLDOWN = 30000; // 30s cooldown before retry probe
 // since day-level totals don't change second-to-second. Idempotent upsert, so
 // missing a tick is harmless (next push replaces).
 const USAGE_PUSH_INTERVAL = 10 * 60 * 1000; // 10 minutes
-const USAGE_SCAN_SINCE_DAYS = 7; // bound the JSONL scan to a recent window
+// Usage scan window (days). The parser reads every JSONL file regardless and
+// filters lines by date *after* parsing, so widening this does NOT increase
+// file I/O — it only grows the POST row-count (days × models ≪ the server's
+// 1000-item / 90-day caps). 30 matches the UI "30d" tier and Claude Code's
+// default transcript retention; 7 left 30d/all showing the same total as 7d
+// (memforge ADR-003 follow-up). Override via MEMFORGE_USAGE_SCAN_DAYS.
+const USAGE_SCAN_SINCE_DAYS = ((): number => {
+  const n = Number(process.env.MEMFORGE_USAGE_SCAN_DAYS);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 30;
+})();
 
 interface ObservationRow {
   id: number;


### PR DESCRIPTION
## Summary

- The sync-poller pushed only a **trailing 7-day** window of measured token usage (`USAGE_SCAN_SINCE_DAYS = 7`). On the server, `usage_daily` therefore never held rows older than 7 days, so the Activity **Measured** card showed an identical total for **7d / 30d / all** (memforge #588).
- Bumped the default to **30** (env-overridable via `MEMFORGE_USAGE_SCAN_DAYS`, defensively parsed: `Number.isFinite && > 0`, else 30).
- The old "keep scan cheap" rationale was inaccurate: `collectJsonlFiles` reads **every** `*.jsonl` regardless of `since`, and `aggregateUsage` filters lines by date **after** parsing. Widening the window does not change file I/O — it only grows the POST row-count (days × models ≪ the server's 1000-item / 90-day caps). Comment corrected.
- Verified locally: JSONL on this machine spans ~33 days (earliest 2026-04-26); 26 days of data older than the old 7-day cutoff become newly visible — so this is **not** a no-op.

## Test plan

- [x] `bun test` — 120 pass
- [x] Typecheck: no new errors from sync-poller (pre-existing mcp-server SDK type mismatch unrelated)
- [ ] After release + local upgrade + poller fires: server `usage_daily` holds ~30 days; Activity 30d differs from 7d

Refs pitimon/memforge#588 (ADR-003 follow-up)