### PR TITLE
chore(release): 2.9.0 — JSONL usage scan window 7→30d

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Release **2.9.0**. Ships #67: the sync-poller now pushes a **30-day** window of measured per-(date,model) token usage (was 7), env-overridable via `MEMFORGE_USAGE_SCAN_DAYS`.

This is the client half of the memforge #588 fix — without it, the server's Activity **Measured** card collapses 7d/30d/all to the same total because `usage_daily` never held rows older than 7 days. Server side (coverage gap surfaced + verified) shipped in memforge v1.17.0.

Version bumped across all 3 manifests: `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`.

## Test plan
- [x] `bun test` — 120 pass (pre-merge on #67)
- [x] version consistent across 3 files (2.9.0)
- [ ] After tag + users upgrade: poller pushes 30d → server Measured 30d differs from 7d

Refs #67, pitimon/memforge#588