### PR TITLE
fix: Windows MCP launch — cross-platform bun resolver (#71)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "MemForge client plugin for Codex and Claude Code - persistent semantic memory.",
   "author": {
     "name": "pitimon",
@@ -26,9 +26,7 @@
     "longDescription": "MemForge Client exposes MCP tools for semantic, hybrid, vector, temporal, cross-project, team, curation, workflow, and status operations against a MemForge server. The Codex package reuses the existing MCP server and reads credentials from ~/.memforge/config.json or environment variables; Claude Code-specific packaging remains available separately.",
     "developerName": "pitimon",
     "category": "Productivity",
-    "capabilities": [
-      "Interactive"
-    ],
+    "capabilities": ["Interactive"],
     "websiteURL": "https://github.com/pitimon/c-memforge",
     "defaultPrompt": [
       "Search my MemForge memory for this project.",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,10 @@
   "mcpServers": {
     "memforge": {
       "type": "stdio",
-      "command": "sh",
+      "command": "bun",
       "args": [
-        "-c",
-        "_E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; printf '%s\\n' \"$PWD/plugin\" \"$PWD\"; ls -dt \"$HOME/.codex/plugins/cache/pitimon-c-memforge/memforge-client\"/[0-9]*/ \"$HOME/.claude/plugins/cache/pitimon-c-memforge/memforge-client\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$HOME/.claude/plugins/marketplaces/pitimon-c-memforge/plugin\"; } | while IFS= read -r _R; do [ -d \"$_R/plugin/src/mcp\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/src/mcp/mcp-server.ts\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"memforge-client: mcp server not found\" >&2; exit 1; }; cd \"$_P\" && exec bun src/mcp/mcp-server.ts"
+        "-e",
+        "const fs=require('fs'),p=require('path'),os=require('os'),u=require('url'); const c=[process.env.CLAUDE_PLUGIN_ROOT,process.env.PLUGIN_ROOT,p.join(process.cwd(),'plugin'),process.cwd(),p.join(os.homedir(),'.claude','plugins','marketplaces','pitimon-c-memforge','plugin')]; for(const base of [p.join(os.homedir(),'.codex','plugins','cache','pitimon-c-memforge','memforge-client'),p.join(os.homedir(),'.claude','plugins','cache','pitimon-c-memforge','memforge-client')]){try{for(const d of fs.readdirSync(base).filter(n=>/^[0-9]/.test(n)).sort().reverse())c.push(p.join(base,d));}catch(e){}} const root=c.filter(Boolean).flatMap(d=>[d,p.join(d,'plugin')]).find(d=>fs.existsSync(p.join(d,'src','mcp','mcp-server.ts'))); if(!root){process.stderr.write('memforge-client: mcp-server.ts not found; set CLAUDE_PLUGIN_ROOT or PLUGIN_ROOT\\n');process.exit(1);} process.chdir(root); import(u.pathToFileURL(p.join(root,'src','mcp','mcp-server.ts')).href).catch(e=>{process.stderr.write('memforge-client: failed to start: '+((e&&e.message)||e)+' (if a module is missing, run: bun install in '+root+')\\n');process.exit(1);});"
       ],
       "env": {
         "CLAUDE_MEM_REMOTE_URL": "https://memclaude.thaicloud.ai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to the MemForge client plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.10.1] - 2026-06-13
+
+### Fixed
+
+- **Windows: MCP server failed to start** ([#71](https://github.com/pitimon/c-memforge/issues/71)).
+  `.mcp.json` launched the server via `"command": "sh"` + a POSIX one-liner, but
+  `sh` is not on `PATH` on Windows (no Git Bash) → Claude Code spawn failed with
+  `ENOENT` before any bun code ran. The claude-mem→memforge sync was unaffected
+  because it launches `bun` directly. Replaced the `sh` launcher with an inline
+  `bun -e` resolver that reads `CLAUDE_PLUGIN_ROOT`/`PLUGIN_ROOT` at runtime,
+  probes the plugin cache cross-platform, and imports the server in-process.
+  Works on Claude Code and Codex (shared `.mcp.json`) across macOS, Linux, Windows.
+- **`process.env.HOME` undefined on Windows** (`src/mcp/api-client.ts`). The
+  claude-mem settings fallback path now uses `os.homedir()` (`USERPROFILE`-aware).
+- **`postinstall` was POSIX-only and swallowed failure** (`mkdir -p … || true`).
+  Replaced with a cross-platform `node` one-liner that creates `~/.memforge` and
+  surfaces real errors instead of hiding them.
+
+### Documentation
+
+- Added Windows prerequisites (PowerShell bun install, `PATH` check) and a
+  Windows first-run dependency-install path to the README troubleshooting guide.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ codex plugin add memforge-client@pitimon-c-memforge
 To pin a release:
 
 ```bash
-codex plugin marketplace add pitimon/c-memforge --ref v2.10.0
+codex plugin marketplace add pitimon/c-memforge --ref v2.10.1
 codex plugin add memforge-client@pitimon-c-memforge
 ```
 
@@ -36,7 +36,15 @@ Configure credentials in `~/.memforge/config.json` as shown below, then start a 
 
 ### Prerequisites
 
-1. **Bun runtime**: `curl -fsSL https://bun.sh/install | bash`
+1. **Bun runtime** (the MCP server runs on bun — `node` cannot substitute):
+   - macOS / Linux: `curl -fsSL https://bun.sh/install | bash`
+   - Windows (PowerShell): `powershell -c "irm bun.sh/install.ps1 | iex"`
+
+   Ensure both `bun` and `node` are on your `PATH` — verify with `bun --version`
+   and `node --version`. (Windows note: the MCP launcher no longer needs a Unix
+   shell as of **v2.10.1**; earlier versions launched via `sh`, which Windows
+   lacks, so the MCP server failed to start.)
+
 2. **claude-mem plugin**: `/plugin marketplace add thedotmack/claude-mem`
 
 ### Step 1: Add Marketplace + Install Plugin
@@ -196,26 +204,33 @@ Sync runs in-process with the MCP server. No separate daemon or background proce
 
 ## Troubleshooting
 
-| Problem                        | Solution                                                                                            |
-| ------------------------------ | --------------------------------------------------------------------------------------------------- |
-| "Remote search not configured" | Check `~/.memforge/config.json` has valid `apiKey`                                                  |
-| "Required: claude-mem plugin"  | Install: `/plugin marketplace add thedotmack/claude-mem`                                            |
-| "bun: command not found"       | Install: `curl -fsSL https://bun.sh/install \| bash`                                                |
-| SSH error on plugin install    | Use HTTPS: `claude plugin marketplace add pitimon/c-memforge`                                       |
-| Sync not working               | Run `mem_status` tool. Check `syncEnabled: true` in config                                          |
-| Slow search                    | Use `mem_search` (FTS) instead of vector. Add date filters. Lower `limit`                           |
-| MCP server won't start         | Missing dependencies — see [First-run dependency install](#first-run-dependency-install) below      |
-| Old observations not syncing   | Remove watermark file — see [Backfill existing observations](#backfill-existing-observations) below |
-| Claude Code hangs on startup   | claude-mem `smart-install.js` runs `bun install` — wait 30-60s or check network                     |
-| Old db-watcher zombie process  | See [Upgrading from v1.x](#upgrading-from-v1x) below                                                |
+| Problem                         | Solution                                                                                                                                                      |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Remote search not configured"  | Check `~/.memforge/config.json` has valid `apiKey`                                                                                                            |
+| "Required: claude-mem plugin"   | Install: `/plugin marketplace add thedotmack/claude-mem`                                                                                                      |
+| "bun: command not found"        | Install: `curl -fsSL https://bun.sh/install \| bash`                                                                                                          |
+| SSH error on plugin install     | Use HTTPS: `claude plugin marketplace add pitimon/c-memforge`                                                                                                 |
+| Sync not working                | Run `mem_status` tool. Check `syncEnabled: true` in config                                                                                                    |
+| Slow search                     | Use `mem_search` (FTS) instead of vector. Add date filters. Lower `limit`                                                                                     |
+| MCP server won't start          | Missing dependencies — see [First-run dependency install](#first-run-dependency-install) below                                                                |
+| MCP fails on Windows (≤ 2.10.0) | The launcher used `sh` (absent on Windows). Update to **v2.10.1+** (`claude plugin install memforge-client@pitimon-c-memforge`) and ensure `bun` is on `PATH` |
+| Old observations not syncing    | Remove watermark file — see [Backfill existing observations](#backfill-existing-observations) below                                                           |
+| Claude Code hangs on startup    | claude-mem `smart-install.js` runs `bun install` — wait 30-60s or check network                                                                               |
+| Old db-watcher zombie process   | See [Upgrading from v1.x](#upgrading-from-v1x) below                                                                                                          |
 
 ### First-run dependency install
 
 After `claude plugin install`, the MCP server may fail to connect because dependencies aren't installed in the cache directory. Fix:
 
 ```bash
-# Find the cache directory and install dependencies
+# macOS / Linux — find the cache directory and install dependencies
 cd ~/.claude/plugins/cache/pitimon-c-memforge/memforge-client/*/
+bun install
+```
+
+```powershell
+# Windows (PowerShell) — newest installed version
+cd (Get-ChildItem "$env:USERPROFILE\.claude\plugins\cache\pitimon-c-memforge\memforge-client" | Sort-Object Name -Descending | Select-Object -First 1).FullName
 bun install
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "memforge-client",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {
     "setup": "bun scripts/setup.ts",
-    "postinstall": "mkdir -p ~/.memforge && (which bun > /dev/null 2>&1 && bun install --no-save 2>/dev/null || true)",
+    "postinstall": "node -e \"require('fs').mkdirSync(require('path').join(require('os').homedir(),'.memforge'),{recursive:true})\"",
     "check": "bun scripts/check-dependency.ts",
     "mcp": "bun src/mcp/mcp-server.ts"
   },

--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -98,7 +98,7 @@ export function initializeApiKey(): void {
   // Fallback to claude-mem settings
   if (!remoteApiKey) {
     try {
-      const settingsPath = `${process.env.HOME}/.claude-mem/settings.json`;
+      const settingsPath = join(homedir(), ".claude-mem", "settings.json");
       const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
       remoteApiKey = settings.CLAUDE_MEM_API_KEY || "";
       configSource = settingsPath;


### PR DESCRIPTION
## Summary
The `memforge` MCP server failed to start on Windows because `.mcp.json` launched it via `"command": "sh"` + a POSIX one-liner — and **`sh` is not on `PATH` on Windows** (no Git Bash), so Claude Code's spawn failed with `ENOENT` before any bun code ran. The claude-mem→memforge sync was unaffected because it launches `bun` directly.

This replaces the `sh` launcher with an inline **`bun -e` resolver** that:
- reads `CLAUDE_PLUGIN_ROOT` / `PLUGIN_ROOT` **at runtime** (the proven mechanism the old `sh` script used — works for both Claude Code and Codex, which share this `.mcp.json` via `.codex-plugin/plugin.json`),
- probes the plugin cache cross-platform (`fs`/`os`/`path`, both `~/.codex` and `~/.claude`),
- `import()`s the server **in-process** (no child process; `pathToFileURL` handles Windows paths),
- exits non-zero with guidance on every failure path (no swallowed errors).

Closes #71.

## Changes
- **`.mcp.json`** — `sh` launcher → inline `bun -e` resolver.
- **`src/mcp/api-client.ts`** — `process.env.HOME` (undefined on Windows) → `homedir()` in the claude-mem settings fallback. Last `HOME` straggler; rest of repo already uses `homedir()`.
- **`package.json`** — `postinstall` POSIX one-liner + `|| true` → cross-platform `node` mkdir that surfaces errors.
- **Version 2.10.0 → 2.10.1** across `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `README.md`.
- **`README.md`** — Windows prereqs, troubleshooting row, Windows first-run-install path.
- **`CHANGELOG.md`** — new file, 2.10.1 entry.

## ⚠️ Gate — do NOT merge until Task 0 passes (draft)
The fix is correct **conditional on one unverified premise**: that Claude Code (and Codex) on **Windows** can spawn a bare `bun` command (resolves `bun.exe`/`bun.cmd` via PATHEXT). This is the *same spawn class* that failed for `sh`, so it must be confirmed on a real Windows machine before merge — macOS testing only exercises the resolver args, not the Windows spawn.

**Task 0 probe** (run in a Windows project, in Claude Code, with bun on PATH):
```jsonc
// .mcp.json
{ "mcpServers": { "probe": { "type": "stdio", "command": "bun",
  "args": ["-e", "console.error('PROBE OK argv='+JSON.stringify(process.argv)); process.exit(1)"] } } }
```
Run `/mcp` and check the log: if it shows `PROBE OK …`, bare-`bun` spawns → this PR is good to merge. If it shows `spawn bun ENOENT`, a Windows-aware command (`bun.exe` or `cmd /c`) is needed and this returns to revision.

## Test plan
- [x] All JSON manifests valid; version synced to 2.10.1 (no `2.10.0` residue).
- [x] macOS: resolver starts the server via the `CLAUDE_PLUGIN_ROOT` path **and** the cache-probe fallback.
- [x] Not-found path exits `1` with a guiding message (no false-success).
- [x] `postinstall` `node` command runs cross-platform, exit 0.
- [ ] **Task 0**: bare-`bun` spawn confirmed on real Windows Claude Code.
- [ ] **Task 0**: bare-`bun` spawn confirmed on Codex (shared `.mcp.json`).
- [ ] Fresh install of 2.10.1 from marketplace → `/mcp` connects → `mem_status` returns on Windows.
- [ ] Regression: macOS/Linux Claude Code + Codex still connect.