### PR TITLE
release: v2.10.2 — correct MCP tool count (28) + example-prompt quickstart

### DIFF
--- a/.claude-plugin/CLAUDE.md
+++ b/.claude-plugin/CLAUDE.md
@@ -4,13 +4,14 @@ Persistent semantic memory for Claude Code, powered by the MemForge SaaS platfor
 
 ## MCP Tools Available
 
-This plugin provides 16 MCP tools for diagnostics, semantic search, and memory management:
+This plugin provides 28 MCP tools for diagnostics, search, retrieval, curation, knowledge graph, skills, and cross-project memory:
 
 ### Diagnostic Tools
 - `mem_status` - Check config, connectivity, auth, and latency
 
 ### Search Tools
-- `mem_semantic_search` - Hybrid search (vector + FTS) with mode selection
+- `mem_semantic_search` - Primary search; hybrid (vector + FTS) with mode selection
+- `mem_temporal_query` - Time-based search ("yesterday", "last week", date ranges)
 - `mem_hybrid_search` - Hybrid search with RRF ranking
 - `mem_vector_search` - Pure vector/embedding search
 - `mem_search` - Full-text search
@@ -31,6 +32,21 @@ All search tools support `offset` parameter for pagination.
 - `mem_cross_project` - Find observations from other projects via concept overlap
 - `mem_team_knowledge` - Search team knowledge pool (shared by team members)
 - `mem_stable_context` - Get stable observation log for prompt caching
+
+### Memory Curation Tools
+- `mem_pin` - Pin an observation to protect it from decay/archival
+- `mem_set_importance` - Override an observation's importance score (0-1)
+- `mem_set_event_date` - Set the temporal event date for time-based queries
+- `mem_set_status` - Set lifecycle status (active/deprecated/superseded/applied/archived)
+- `mem_contradict` - Mark an observation stale and record a correction
+- `mem_drift_check` - Find the oldest unverified observations
+
+### Skill Tools (SkillNet)
+- `mem_skill_search` - Search skills by query, category, or tags
+- `mem_skill_get` - Get a specific skill with full details
+- `mem_skill_related` - Find related skills via graph traversal
+- `mem_skill_create` - Extract a reusable skill from observations
+- `mem_skill_discover` - Browse the public skill catalog
 
 ### Data Tools
 - `mem_ingest` - Ingest observations into the server

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "MemForge client plugin for Codex and Claude Code - persistent semantic memory.",
   "author": {
     "name": "pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the MemForge client plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.10.2] - 2026-06-13
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the MemForge client plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- **Corrected MCP tool count to 28** (was "27" in README and "16" in the plugin
+  `CLAUDE.md`). Verified against `getAllTools()` — the 4 `mem_snapshot_*` tools
+  are defined but server-side only, not exposed by this client.
+- Added the missing tool groups to `.claude-plugin/CLAUDE.md` (temporal query,
+  6 memory-curation tools, 5 SkillNet tools).
+- Added a **"Try It — Example Prompts"** section to the README — copy-paste
+  natural-language prompts grouped by feature (verify setup, search, cross-project,
+  knowledge graph, skills, curation), each annotated with the tool it invokes.
+
 ## [2.10.1] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,72 @@ Restart to load the plugin. Verify with `mem_status` tool — should show connec
 
 ---
 
-## MCP Tools (27)
+## Try It — Example Prompts
+
+You don't call tools directly — just talk to Claude in natural language, and it
+picks the right MemForge tool for you. Copy any prompt below into Claude Code.
+The **Tool** column shows what runs under the hood (handy for verifying which
+feature you're exercising).
+
+### 1. Verify your setup (run these first)
+
+| Prompt                                                    | Tool                  | Expect                                            |
+| --------------------------------------------------------- | --------------------- | ------------------------------------------------- |
+| `Check my MemForge status, tier, and quota.`              | `mem_status`          | Connectivity OK + your tier and observation count |
+| `Search my MemForge memory for anything about this repo.` | `mem_semantic_search` | A list of past observations (empty if brand new)  |
+
+If `mem_status` returns connectivity OK, the plugin is working. New accounts
+start empty — your observations appear automatically after a few sessions (sync
+is background, no manual steps).
+
+### 2. Search & recall
+
+| Prompt                                                   | Tool                           |
+| -------------------------------------------------------- | ------------------------------ |
+| `How did I fix the last deployment bug?`                 | `mem_semantic_search` (hybrid) |
+| `What did I work on yesterday?` · `…last week?`          | `mem_temporal_query`           |
+| `Find observations similar to "rate limiting strategy".` | `mem_vector_search`            |
+| `Search my memory for the keyword "postgres".`           | `mem_search` (full-text)       |
+| `Show my 10 most recent observations.`                   | `mem_semantic_recent`          |
+| `Show the context around observation 102945.`            | `mem_timeline`                 |
+
+### 3. Cross-project & team
+
+| Prompt                                                           | Tool                             |
+| ---------------------------------------------------------------- | -------------------------------- |
+| `Find related work from my other projects about authentication.` | `mem_cross_project`              |
+| `Search the team knowledge pool for our incident runbook.`       | `mem_team_knowledge` (Team tier) |
+
+### 4. Knowledge graph
+
+| Prompt                                                    | Tool                 |
+| --------------------------------------------------------- | -------------------- |
+| `What is connected to the entity "Redis" in my memory?`   | `mem_entity_lookup`  |
+| `Show relationships where the predicate is "depends on".` | `mem_triplets_query` |
+
+### 5. Skills (SkillNet)
+
+| Prompt                                                | Tool                 |
+| ----------------------------------------------------- | -------------------- |
+| `Search my skills for a database migration workflow.` | `mem_skill_search`   |
+| `Browse the public skill catalog.`                    | `mem_skill_discover` |
+| `Turn my recent work into a reusable skill.`          | `mem_skill_create`   |
+
+### 6. Curate memory
+
+| Prompt                                                | Tool              |
+| ----------------------------------------------------- | ----------------- |
+| `Pin observation 102945 so it never gets archived.`   | `mem_pin`         |
+| `Mark observation 100200 as deprecated.`              | `mem_set_status`  |
+| `Observation 99000 is wrong — record the correction.` | `mem_contradict`  |
+| `Which of my observations are oldest and unverified?` | `mem_drift_check` |
+
+> Every tool response includes a `suggested_next` hint pointing you to the
+> natural follow-up tool — so you can keep going without memorizing the catalog.
+
+---
+
+## MCP Tools (28)
 
 ### Search (start here)
 
@@ -190,7 +255,7 @@ claude-mem (local)          memforge-client (this plugin)          MemForge Serv
 LLM creates structured  →  SyncPoller reads SQLite     →  POST /api/sync/push
 observations in SQLite      every 2-10s (adaptive)         stores + embeds + extracts entities
 
-                            27 MCP tools  ←─────────────  Search, curation, graph, skills
+                            28 MCP tools  ←─────────────  Search, curation, graph, skills
                             + workflow hints                + 15 background workers
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ codex plugin add memforge-client@pitimon-c-memforge
 To pin a release:
 
 ```bash
-codex plugin marketplace add pitimon/c-memforge --ref v2.10.1
+codex plugin marketplace add pitimon/c-memforge --ref v2.10.2
 codex plugin add memforge-client@pitimon-c-memforge
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Documentation accuracy + usability pass for plugin members, released as **v2.10.2**.

- **Corrected the MCP tool count to 28.** README said "27" (header + how-it-works diagram) and `.claude-plugin/CLAUDE.md` said "16". Verified against `getAllTools()` in `src/mcp/handlers/index.ts` — it spreads 10 handler groups totalling **28** tools. The 4 `mem_snapshot_*` tools are *defined* (`snapshot-handlers.ts`) but **not** registered in `getAllTools`, so they're server-side only and correctly excluded.
- **`.claude-plugin/CLAUDE.md`** (loaded as plugin context, so accuracy is functional): added the 12 tools it never listed — `mem_temporal_query`, the 6 memory-curation tools, and the 5 SkillNet tools. This is the main reason for cutting a release: the corrected context ships to users.
- **README — new "Try It — Example Prompts" section**: copy-paste natural-language prompts grouped by feature, each annotated with the tool it invokes, so members can confirm functionality end-to-end.
- **Version bump 2.10.1 → 2.10.2** across all 4 manifests + README install pin; CHANGELOG `[2.10.2]`.

## Verification
- [x] `getAllTools()` exposes exactly 28 tools; README tables + CLAUDE.md bullets both = 28.
- [x] Every `mem_*` referenced in the README is a real defined tool (no orphans).
- [x] No stale "27" / "16" counts remain in any `*.md`.
- [x] Version 2.10.2 consistent across all manifests; JSON valid.