### PR TITLE
feat(mcp): mem_handoff + mem_resume, first commands, v2.11.0

### DIFF
--- a/.claude-plugin/CLAUDE.md
+++ b/.claude-plugin/CLAUDE.md
@@ -4,7 +4,7 @@ Persistent semantic memory for Claude Code, powered by the MemForge SaaS platfor
 
 ## MCP Tools Available
 
-This plugin provides 28 MCP tools for diagnostics, search, retrieval, curation, knowledge graph, skills, and cross-project memory:
+This plugin provides 30 MCP tools for diagnostics, search, retrieval, curation, knowledge graph, skills, session continuity, and cross-project memory:
 
 ### Diagnostic Tools
 - `mem_status` - Check config, connectivity, auth, and latency
@@ -51,6 +51,16 @@ All search tools support `offset` parameter for pagination.
 ### Data Tools
 - `mem_ingest` - Ingest observations into the server
 - `mem_workflow_suggest` - Suggest workflows based on context
+
+### Session Continuity Tools
+- `mem_handoff` - Write a session handoff (what's done, what's next, open loops) for cross-session continuity
+- `mem_resume` - Resume work: latest handoff + open loops + prior handoffs + latest retrospective for a project
+
+## Commands
+
+- `/forward` - Write a structured session handoff before ending/clearing (calls `mem_handoff`)
+- `/resume` - Resume work by pulling the latest handoff, open loops, and recent context (calls `mem_resume`)
+- `/retrospective` - Write a first-person session retrospective (AI Diary + Honest Feedback) into memforge (calls `mem_ingest`)
 
 ## Configuration
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.10.2",
+      "version": "2.11.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "description": "MemForge client plugin for Codex and Claude Code - persistent semantic memory.",
   "author": {
     "name": "pitimon",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to the MemForge client plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] - 2026-07-06
+
+### Added
+
+- **`mem_handoff` / `mem_resume` MCP tools** for cross-session continuity
+  ([memforge#689](https://github.com/pitimon/memforge/issues/689)). `mem_handoff`
+  writes a structured session handoff (`project`, `next_steps`, optional `context`
+  and `open_loops`, optional `agent_id`/`agent_type`) via `POST /api/v1/handoff`.
+  `mem_resume` fetches the latest handoff, open loops, prior handoff history, and
+  the latest retrospective for a project via `GET /api/v1/resume`.
+- **`/forward`, `/resume`, `/retrospective` commands**
+  ([memforge#690](https://github.com/pitimon/memforge/issues/690)). `/forward`
+  writes a handoff at the end of a session; `/resume` pulls handoff history at the
+  start of the next one; `/retrospective` writes a first-person session
+  retrospective into memforge via `mem_ingest`, with a **mandatory AI Diary +
+  Honest Feedback** structure — the command refuses to submit if either section
+  is missing or empty.
+- New endpoint allowlist entries: `/api/v1/handoff`, `/api/v1/resume`.
+- New Zod input-validation schemas for `mem_handoff` and `mem_resume`.
+- `mem_resume` renders `latest_retrospective` per the pinned server shape
+  `{id, created_at, title, narrative}` (title + a <= 300 char narrative excerpt).
+
+### Requirements
+
+- Requires **memforge server >= v1.20.0** for the `/api/v1/handoff` and
+  `/api/v1/resume` endpoints. Using this client version against an older server
+  will fail with 404s on both new tools.
+
 ## [2.10.2] - 2026-06-13
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ codex plugin add memforge-client@pitimon-c-memforge
 To pin a release:
 
 ```bash
-codex plugin marketplace add pitimon/c-memforge --ref v2.10.2
+codex plugin marketplace add pitimon/c-memforge --ref v2.11.0
 codex plugin add memforge-client@pitimon-c-memforge
 ```
 
@@ -147,7 +147,7 @@ is background, no manual steps).
 
 ---
 
-## MCP Tools (28)
+## MCP Tools (30)
 
 ### Search (start here)
 
@@ -212,7 +212,22 @@ is background, no manual steps).
 | `mem_workflow_suggest` | Get workflow suggestions based on context         |
 | `mem_status`           | Check config, connectivity, auth, tier, and quota |
 
+### Session Continuity
+
+| Tool          | Purpose                                                                          |
+| ------------- | --------------------------------------------------------------------------------- |
+| `mem_handoff` | Write a session handoff (what's done, what's next, open loops)                   |
+| `mem_resume`  | Resume work: latest handoff + open loops + prior handoffs + latest retrospective  |
+
 All tool responses include **workflow hints** (`suggested_next`) guiding you to the right follow-up tool.
+
+## Commands
+
+| Command          | Purpose                                                                            |
+| ----------------- | ----------------------------------------------------------------------------------- |
+| `/forward`       | Write a structured session handoff before ending/clearing (calls `mem_handoff`)    |
+| `/resume`        | Resume work: fetch latest handoff, open loops, recent context (calls `mem_resume`) |
+| `/retrospective` | Write a first-person session retrospective — AI Diary + Honest Feedback (calls `mem_ingest`) |
 
 ---
 
@@ -255,7 +270,7 @@ claude-mem (local)          memforge-client (this plugin)          MemForge Serv
 LLM creates structured  →  SyncPoller reads SQLite     →  POST /api/sync/push
 observations in SQLite      every 2-10s (adaptive)         stores + embeds + extracts entities
 
-                            28 MCP tools  ←─────────────  Search, curation, graph, skills
+                            30 MCP tools  ←─────────────  Search, curation, graph, skills
                             + workflow hints                + 15 background workers
 ```
 

--- a/commands/forward.md
+++ b/commands/forward.md
@@ -1,0 +1,36 @@
+---
+description: Write a session handoff before ending/clearing — what's done, what's next, open loops
+---
+
+Write a structured handoff so the next session (yours or another agent's) can pick up
+without re-discovering context. Respond in the user's language.
+
+1. **Derive the project**: Use the current working directory name, the repo name
+   (`git remote get-url origin` if available), or ask the user if ambiguous. Do not
+   guess silently on a genuinely unclear multi-project session — confirm with the user.
+
+2. **Summarize completed work**: Review this session's conversation and produce a
+   concise narrative — what was done and why, key decisions made, files touched.
+   This becomes the `context` field.
+
+3. **Enumerate next steps**: List concrete, imperative, actionable items for the next
+   session (e.g. "Run the test suite and fix failures in X", not "testing"). This is
+   required and must be non-empty — if there is truly nothing left, say so explicitly
+   to the user instead of inventing filler steps.
+
+4. **List open loops**: Unresolved questions, blockers, or threads that need a decision
+   before work can continue (e.g. "Waiting on user to confirm schema field name").
+   Omit this field if there are none — do not pad it.
+
+5. **Call `mem_handoff`** with:
+   - `project` (required)
+   - `next_steps` (required, array of strings)
+   - `context` (optional narrative)
+   - `open_loops` (optional array of strings)
+   - `agent_id` / `agent_type` if known
+
+6. **Confirm to the user**: Report the handoff `id` returned, and a one-line summary
+   of what was recorded (e.g. "Handoff #42 recorded for project X — 3 next steps, 1 open loop.").
+
+Do not fabricate next steps or open loops that were not actually discussed in this
+session — a handoff is only useful if it reflects reality.

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -1,0 +1,28 @@
+---
+description: Resume work: fetch latest handoff, open loops, and recent context for this project
+---
+
+Resume a project by pulling its handoff history. Respond in the user's language.
+
+1. **Derive the project**: Use the current working directory name, the repo name
+   (`git remote get-url origin` if available), or ask the user if ambiguous.
+
+2. **Call `mem_resume`** with `project` (required) and optionally `limit` (max prior
+   handoffs to include, default 3). The tool returns already-rendered text — present
+   it to the user directly, do not re-parse or reformat it.
+
+3. **If the output indicates no handoff history exists** (it will say plainly that
+   none was found and suggest recording one): relay that guidance to the user, and
+   suggest running `/forward` at the end of this session so the next one has
+   something to resume from. Stop here.
+
+4. **Otherwise, present the tool's output as-is** — it is already ordered as:
+   - **NEXT STEPS** first — the most important part, numbered, from the latest handoff.
+   - **OPEN LOOPS** next — unresolved questions/blockers, bulleted.
+   - **Prior handoffs** — one line each (id/date), not full contents, so the user gets
+     a sense of history without a wall of text.
+   - **Latest retrospective excerpt**, if present — a short excerpt (not the full
+     retrospective) so the user can decide whether to dig further.
+
+5. Keep the presentation scannable — headers, short lines. This is meant to be read
+   in a few seconds at the start of a session, not a full report.

--- a/commands/retrospective.md
+++ b/commands/retrospective.md
@@ -1,0 +1,65 @@
+---
+description: Write a first-person session retrospective (AI Diary + Honest Feedback) into memforge
+---
+
+Write a first-person retrospective of this session and submit it to memforge via
+`mem_ingest`. Respond in the user's language for any commentary to the user, but write
+the retrospective narrative itself in clear prose (English is fine unless the session
+was conducted in another language).
+
+## Required structure — HARD RULE
+
+The retrospective narrative MUST contain exactly these two sections, with these exact
+headings:
+
+```
+## AI Diary
+<first-person narrative of the session: what I did, what surprised me, how decisions
+felt in the moment, where I hesitated or changed approach>
+
+## Honest Feedback
+<frank assessment: what went poorly, what the human could have done better or
+communicated more clearly, what I could have done better>
+```
+
+**REFUSE to submit if either section is missing or empty.** If you find yourself about
+to call `mem_ingest` without a genuine, non-trivial "AI Diary" or "Honest Feedback"
+section, STOP — do not submit a placeholder or a one-line stub. Instead, generate the
+missing section properly first (actually reflect on the session), or ask the user for
+input on the missing part, then proceed. A retrospective with a blank or token section
+is worse than no retrospective at all — do not let politeness or a rush to finish
+produce empty sections.
+
+## Steps
+
+1. **Derive the project**: current working directory name, repo name, or ask the user
+   if ambiguous.
+
+2. **Write the "AI Diary" section**: a genuine first-person account of this session —
+   what was attempted, what worked, what surprised you, where you changed course, how
+   ambiguous instructions were resolved.
+
+3. **Write the "Honest Feedback" section**: a frank, specific assessment — what went
+   poorly, what the human could improve (unclear instructions, missing context, etc.),
+   and what you (the AI) could have done better. Do not soften this into generic
+   praise — the value of this section is candor.
+
+4. **Verify both sections are present and non-empty** before proceeding. If either is
+   missing, go back to step 2/3 — do not submit.
+
+5. **Submit via `mem_ingest`** with:
+   ```json
+   {
+     "items": [
+       {
+         "type": "retrospective",
+         "title": "Retrospective: <project> <date>",
+         "narrative": "<full text, including both ## AI Diary and ## Honest Feedback sections>",
+         "project": "<project>"
+       }
+     ]
+   }
+   ```
+
+6. **Confirm to the user**: report the observation id returned and confirm both
+   sections were included.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/src/mcp/__tests__/session-handlers.test.ts
+++ b/src/mcp/__tests__/session-handlers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for mem_resume formatting (memforge #74 — lifetime-memory Wave 2).
+ *
+ * F2 regression: the server's GET /api/v1/resume returns
+ * `latest_retrospective = {id, created_at, title, narrative}`
+ * (see memforge `formatRetrospective` in docker/scripts/api/routes/session.ts).
+ * The fixtures below use those EXACT server keys — not the client's own
+ * `RetrospectiveRecord` type re-encoded — so a future type/decode mismatch
+ * fails this test instead of silently dropping the section.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { formatResume, type ResumeResponse } from "../handlers/session-handlers";
+
+describe("formatResume", () => {
+  test("renders the Latest Retrospective section from a literal server-shaped fixture", () => {
+    // Literal JSON as GET /api/v1/resume actually returns it — server keys only.
+    const serverResponse: ResumeResponse = JSON.parse(`{
+      "latest_handoff": {
+        "id": 42,
+        "project": "memforge",
+        "next_steps": ["Ship fix 1"],
+        "context": "Investigated F2 retrospective drop.",
+        "open_loops": [],
+        "created_at": "2026-07-01T00:00:00.000Z"
+      },
+      "prior_handoffs": [],
+      "latest_retrospective": {
+        "id": 7,
+        "created_at": "2026-06-30T00:00:00.000Z",
+        "title": "Session Handoff Wave 2 Retro",
+        "narrative": "We shipped mem_handoff/mem_resume; the retrospective field mismatch was caught in review before release."
+      },
+      "open_loops": [],
+      "empty": false
+    }`);
+
+    const output = formatResume("memforge", serverResponse);
+
+    expect(output).toContain("## Latest Retrospective");
+    expect(output).toContain("Session Handoff Wave 2 Retro");
+    expect(output).toContain(
+      "We shipped mem_handoff/mem_resume; the retrospective field mismatch was caught in review before release.",
+    );
+  });
+
+  test("excerpts a long retrospective narrative to <= 300 chars", () => {
+    const longNarrative = "x".repeat(500);
+    const serverResponse: ResumeResponse = {
+      latest_handoff: null,
+      prior_handoffs: [],
+      latest_retrospective: {
+        id: 1,
+        created_at: "2026-06-30T00:00:00.000Z",
+        title: "Long Retro",
+        narrative: longNarrative,
+      },
+      open_loops: [],
+      empty: false,
+    };
+
+    const output = formatResume("memforge", serverResponse);
+    const retroSection = output.split("## Latest Retrospective")[1] ?? "";
+
+    // 300 chars of "x" plus the "..." ellipsis marker, no more.
+    expect(retroSection).toContain("x".repeat(300) + "...");
+    expect(retroSection).not.toContain("x".repeat(301));
+  });
+
+  test("omits the Latest Retrospective section when latest_retrospective is null", () => {
+    const serverResponse: ResumeResponse = {
+      latest_handoff: null,
+      prior_handoffs: [],
+      latest_retrospective: null,
+      open_loops: [],
+      empty: false,
+    };
+
+    const output = formatResume("memforge", serverResponse);
+
+    expect(output).not.toContain("## Latest Retrospective");
+  });
+
+  test("renders the empty-state guidance when empty is true", () => {
+    const serverResponse: ResumeResponse = {
+      latest_handoff: null,
+      prior_handoffs: [],
+      latest_retrospective: null,
+      open_loops: [],
+      empty: true,
+      guidance: "No handoff recorded for memforge yet. Use mem_handoff at session end to leave one.",
+    };
+
+    const output = formatResume("memforge", serverResponse);
+
+    expect(output).toContain(
+      "No handoff history found for project \"memforge\".",
+    );
+    expect(output).toContain("No handoff recorded for memforge yet.");
+  });
+
+  test("renders next steps, open loops, context, and prior handoffs", () => {
+    const serverResponse: ResumeResponse = {
+      latest_handoff: {
+        id: 1,
+        project: "memforge",
+        next_steps: ["Do A", "Do B"],
+        context: "Some narrative context.",
+        open_loops: ["Unresolved question"],
+        created_at: "2026-07-01T00:00:00.000Z",
+      },
+      prior_handoffs: [
+        { id: 0, project: "memforge", created_at: "2026-06-01T00:00:00.000Z" },
+      ],
+      latest_retrospective: null,
+      open_loops: [],
+      empty: false,
+    };
+
+    const output = formatResume("memforge", serverResponse);
+
+    expect(output).toContain("## NEXT STEPS");
+    expect(output).toContain("1. Do A");
+    expect(output).toContain("2. Do B");
+    expect(output).toContain("## OPEN LOOPS");
+    expect(output).toContain("- Unresolved question");
+    expect(output).toContain("## Context");
+    expect(output).toContain("Some narrative context.");
+    expect(output).toContain("## Prior Handoffs");
+    expect(output).toContain("1 prior handoff(s)");
+  });
+});

--- a/src/mcp/__tests__/validation.test.ts
+++ b/src/mcp/__tests__/validation.test.ts
@@ -240,6 +240,108 @@ describe("validateToolInput", () => {
     });
   });
 
+  describe("mem_handoff", () => {
+    test("accepts valid input", () => {
+      const result = validateToolInput("mem_handoff", {
+        project: "memforge",
+        next_steps: ["Finish task C1", "Run tests"],
+      });
+      expect(result.project).toBe("memforge");
+      expect(result.next_steps).toEqual(["Finish task C1", "Run tests"]);
+    });
+
+    test("accepts optional fields", () => {
+      const result = validateToolInput("mem_handoff", {
+        project: "memforge",
+        next_steps: ["Ship it"],
+        context: "Implemented session handoff tools",
+        open_loops: ["Server contract not yet deployed"],
+        agent_id: "agent-1",
+        agent_type: "fast-worker",
+      });
+      expect(result.context).toBe("Implemented session handoff tools");
+      expect(result.open_loops).toEqual(["Server contract not yet deployed"]);
+    });
+
+    test("rejects missing project", () => {
+      expect(() =>
+        validateToolInput("mem_handoff", { next_steps: ["a"] }),
+      ).toThrow("Invalid input");
+    });
+
+    test("rejects empty project", () => {
+      expect(() =>
+        validateToolInput("mem_handoff", { project: "", next_steps: ["a"] }),
+      ).toThrow("Invalid input");
+    });
+
+    test("rejects missing next_steps", () => {
+      expect(() =>
+        validateToolInput("mem_handoff", { project: "memforge" }),
+      ).toThrow("Invalid input");
+    });
+
+    test("rejects empty next_steps array", () => {
+      expect(() =>
+        validateToolInput("mem_handoff", {
+          project: "memforge",
+          next_steps: [],
+        }),
+      ).toThrow("Invalid input");
+    });
+
+    test("rejects non-string entries in next_steps", () => {
+      expect(() =>
+        validateToolInput("mem_handoff", {
+          project: "memforge",
+          next_steps: [123],
+        }),
+      ).toThrow("Invalid input");
+    });
+  });
+
+  describe("mem_resume", () => {
+    test("accepts valid input with default limit", () => {
+      const result = validateToolInput("mem_resume", { project: "memforge" });
+      expect(result.project).toBe("memforge");
+      expect(result.limit).toBe(3);
+    });
+
+    test("accepts explicit limit", () => {
+      const result = validateToolInput("mem_resume", {
+        project: "memforge",
+        limit: 5,
+      });
+      expect(result.limit).toBe(5);
+    });
+
+    test("coerces string limit to number", () => {
+      const result = validateToolInput("mem_resume", {
+        project: "memforge",
+        limit: "10",
+      });
+      expect(result.limit).toBe(10);
+    });
+
+    test("rejects missing project", () => {
+      expect(() => validateToolInput("mem_resume", {})).toThrow(
+        "Invalid input",
+      );
+    });
+
+    test("rejects empty project", () => {
+      expect(() =>
+        validateToolInput("mem_resume", { project: "" }),
+      ).toThrow("Invalid input");
+    });
+
+    test("rejects limit > 50", () => {
+      expect(() =>
+        validateToolInput("mem_resume", { project: "memforge", limit: 100 }),
+      ).toThrow("Invalid input");
+    });
+  });
+
   describe("unknown tool", () => {
     test("passes through args for unknown tool", () => {
       const args = { foo: "bar" };

--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -281,6 +281,8 @@ const ALLOWED_API_PATHS = new Set([
   "/api/skills",
   "/api/search/temporal",
   "/api/observations/drift-check",
+  "/api/v1/handoff",
+  "/api/v1/resume",
   "/health",
 ]);
 

--- a/src/mcp/handlers/index.ts
+++ b/src/mcp/handlers/index.ts
@@ -19,6 +19,7 @@ import { contextHandlers } from "./context-handlers";
 import { teamHandlers } from "./team-handlers";
 import { skillHandlers } from "./skill-handlers";
 import { metadataHandlers } from "./metadata-handlers";
+import { sessionHandlers } from "./session-handlers";
 
 export {
   searchHandlers,
@@ -31,6 +32,7 @@ export {
   teamHandlers,
   skillHandlers,
   metadataHandlers,
+  sessionHandlers,
 };
 
 // Re-export individual handlers for direct imports
@@ -72,6 +74,7 @@ export {
   memContradict,
   memDriftCheck,
 } from "./metadata-handlers";
+export { memHandoff, memResume } from "./session-handlers";
 
 /**
  * Get all tool definitions for MCP server registration.
@@ -90,5 +93,6 @@ export function getAllTools(): ToolDefinition[] {
     ...teamHandlers,
     ...skillHandlers,
     ...metadataHandlers,
+    ...sessionHandlers,
   ];
 }

--- a/src/mcp/handlers/session-handlers.ts
+++ b/src/mcp/handlers/session-handlers.ts
@@ -1,0 +1,267 @@
+/**
+ * MCP Session Handoff Handlers (memforge #74 — lifetime-memory Wave 2)
+ *
+ * mem_handoff / mem_resume tools for cross-session continuity:
+ * write a structured handoff at the end of a session, resume it
+ * (latest handoff + open loops + prior handoffs + retrospective) at the
+ * start of the next one.
+ */
+
+import type { ToolDefinition } from "../types";
+import { callRemoteAPI, postRemoteAPI, wrapError, wrapSuccess } from "../api-client";
+
+/** Response shape from POST /api/v1/handoff */
+interface HandoffCreateResponse {
+  id: number;
+  project?: string;
+  created_at?: string;
+}
+
+/** A single handoff record as returned by GET /api/v1/resume */
+interface HandoffRecord {
+  id: number;
+  project: string;
+  next_steps?: string[];
+  context?: string;
+  open_loops?: string[];
+  agent_id?: string;
+  agent_type?: string;
+  created_at?: string;
+}
+
+/**
+ * A retrospective record as returned by GET /api/v1/resume — pinned to the
+ * exact server shape (memforge `formatRetrospective` in
+ * docker/scripts/api/routes/session.ts): {id, created_at, title, narrative}.
+ */
+interface RetrospectiveRecord {
+  id?: number;
+  title?: string;
+  narrative?: string;
+  created_at?: string;
+}
+
+/** Response shape from GET /api/v1/resume */
+export interface ResumeResponse {
+  latest_handoff: HandoffRecord | null;
+  prior_handoffs: HandoffRecord[];
+  latest_retrospective: RetrospectiveRecord | null;
+  open_loops: string[];
+  empty: boolean;
+  guidance?: string;
+}
+
+/** Truncate long text for compact rendering, appending an ellipsis marker */
+function excerpt(text: string, maxLen = 500): string {
+  return text.length > maxLen ? `${text.slice(0, maxLen)}...` : text;
+}
+
+/** mem_handoff tool definition */
+export const memHandoff: ToolDefinition = {
+  name: "mem_handoff",
+  description:
+    "Write a session handoff (what's done, what's next, open loops) for cross-session continuity — lifetime-memory Wave 2",
+  inputSchema: {
+    type: "object",
+    properties: {
+      project: {
+        type: "string",
+        description: "Project this handoff belongs to (required)",
+      },
+      next_steps: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Concrete next steps for the next session to pick up (required, non-empty)",
+      },
+      context: {
+        type: "string",
+        description:
+          "Optional narrative context — what was done and why, key decisions made",
+      },
+      open_loops: {
+        type: "array",
+        items: { type: "string" },
+        description: "Optional unresolved questions or blockers to track",
+      },
+      agent_id: {
+        type: "string",
+        description: "Optional identifier of the agent writing this handoff",
+      },
+      agent_type: {
+        type: "string",
+        description:
+          "Optional agent type/role (e.g. 'orchestrator', 'fast-worker')",
+      },
+    },
+    required: ["project", "next_steps"],
+  },
+  handler: async (args) => {
+    const project = args.project as string;
+    const nextSteps = args.next_steps as string[];
+
+    if (typeof project !== "string" || project.trim().length === 0) {
+      return wrapError(
+        new Error("project is required and must be a non-empty string."),
+      );
+    }
+    if (!Array.isArray(nextSteps) || nextSteps.length === 0) {
+      return wrapError(
+        new Error(
+          "next_steps is required and must be a non-empty array of strings.",
+        ),
+      );
+    }
+
+    try {
+      const data = (await postRemoteAPI(
+        "/api/v1/handoff",
+        args,
+      )) as HandoffCreateResponse;
+
+      const openLoops = args.open_loops as string[] | undefined;
+      return wrapSuccess(
+        `Handoff #${data.id} recorded for project "${project}" — ` +
+          `${nextSteps.length} next step(s)` +
+          (openLoops && openLoops.length > 0
+            ? `, ${openLoops.length} open loop(s)`
+            : "") +
+          ".",
+      );
+    } catch (error) {
+      return wrapError(error);
+    }
+  },
+};
+
+/** Render the "## NEXT STEPS" section, or "" if there are none. */
+function renderNextSteps(latest: HandoffRecord | null): string {
+  if (!latest?.next_steps || latest.next_steps.length === 0) return "";
+  let section = "## NEXT STEPS\n";
+  latest.next_steps.forEach((step, i) => {
+    section += `${i + 1}. ${step}\n`;
+  });
+  return `${section}\n`;
+}
+
+/** Render the "## OPEN LOOPS" section (top-level open_loops wins, else latest handoff's). */
+function renderOpenLoops(data: ResumeResponse): string {
+  const openLoops =
+    data.open_loops && data.open_loops.length > 0
+      ? data.open_loops
+      : data.latest_handoff?.open_loops;
+  if (!openLoops || openLoops.length === 0) return "";
+  let section = "## OPEN LOOPS\n";
+  for (const loop of openLoops) {
+    section += `- ${loop}\n`;
+  }
+  return `${section}\n`;
+}
+
+/** Render the "## Context" section from the latest handoff's narrative. */
+function renderContext(latest: HandoffRecord | null): string {
+  if (!latest?.context) return "";
+  return `## Context\n${excerpt(latest.context)}\n\n`;
+}
+
+/** Render the "## Prior Handoffs" summary line. */
+function renderPriorHandoffs(priorHandoffs: HandoffRecord[]): string {
+  const priorCount = priorHandoffs.length;
+  if (priorCount === 0) return "";
+  const dates = priorHandoffs
+    .map((h) => h.created_at)
+    .filter(Boolean)
+    .join(", ");
+  return (
+    `## Prior Handoffs\n${priorCount} prior handoff(s)` +
+    (dates ? ` (${dates})` : "") +
+    "\n\n"
+  );
+}
+
+/** Render the "## Latest Retrospective" section (title + narrative excerpt, <= 300 chars). */
+function renderRetrospective(
+  retrospective: RetrospectiveRecord | null,
+): string {
+  if (!retrospective || !retrospective.narrative) return "";
+  const heading = retrospective.title
+    ? `## Latest Retrospective: ${retrospective.title}\n`
+    : "## Latest Retrospective\n";
+  return `${heading}${excerpt(retrospective.narrative, 300)}\n`;
+}
+
+/** Render the empty-state message when no handoff history exists for a project. */
+function formatEmptyResume(project: string, data: ResumeResponse): string {
+  return (
+    `No handoff history found for project "${project}".\n\n` +
+    (data.guidance ||
+      "Start a new handoff with mem_handoff when you have progress to record.")
+  );
+}
+
+/**
+ * Format the full /api/v1/resume response into rendered text — the client-side
+ * twin of memforge's server-side `buildResumePayload` (docker/scripts/api/routes/session.ts).
+ */
+export function formatResume(project: string, data: ResumeResponse): string {
+  if (data.empty) {
+    return formatEmptyResume(project, data);
+  }
+
+  let output = `# Resume: ${project}\n\n`;
+  output += renderNextSteps(data.latest_handoff);
+  output += renderOpenLoops(data);
+  output += renderContext(data.latest_handoff);
+  output += renderPriorHandoffs(data.prior_handoffs || []);
+  output += renderRetrospective(data.latest_retrospective);
+
+  return output.trim();
+}
+
+/** mem_resume tool definition */
+export const memResume: ToolDefinition = {
+  name: "mem_resume",
+  description:
+    "Resume work: latest handoff + open loops + prior handoffs + latest retrospective for a project",
+  inputSchema: {
+    type: "object",
+    properties: {
+      project: {
+        type: "string",
+        description: "Project to resume work on (required)",
+      },
+      limit: {
+        type: "number",
+        description: "Max prior handoffs to include (default: 3)",
+      },
+    },
+    required: ["project"],
+  },
+  handler: async (args) => {
+    const project = args.project as string;
+
+    if (typeof project !== "string" || project.trim().length === 0) {
+      return wrapError(
+        new Error("project is required and must be a non-empty string."),
+      );
+    }
+
+    const limit =
+      typeof args.limit === "number" && Number.isFinite(args.limit)
+        ? args.limit
+        : 3;
+
+    try {
+      const data = (await callRemoteAPI("/api/v1/resume", {
+        project,
+        limit,
+      })) as ResumeResponse;
+
+      return wrapSuccess(formatResume(project, data));
+    } catch (error) {
+      return wrapError(error);
+    }
+  },
+};
+
+export const sessionHandlers: ToolDefinition[] = [memHandoff, memResume];

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -280,6 +280,21 @@ const schemas: Record<string, z.ZodType> = {
     project: z.string().max(200).optional(),
     limit: limitField(100, 20),
   }),
+
+  // Session handoff tools (memforge #74 — lifetime-memory Wave 2)
+  mem_handoff: z.object({
+    project: z.string().min(1).max(200),
+    next_steps: z.array(z.string().min(1).max(2000)).min(1).max(50),
+    context: z.string().max(20000).optional(),
+    open_loops: z.array(z.string().min(1).max(2000)).max(50).optional(),
+    agent_id: z.string().max(200).optional(),
+    agent_type: z.string().max(100).optional(),
+  }),
+
+  mem_resume: z.object({
+    project: z.string().min(1).max(200),
+    limit: limitField(50, 3),
+  }),
 };
 
 /**


### PR DESCRIPTION
## Summary
- 2 MCP tools (28→30): `mem_handoff` → POST /api/v1/handoff, `mem_resume` → GET /api/v1/resume; endpoint allowlist + Zod schemas for both; resume renders `latest_retrospective` per pinned server shape (review caught silent field-drift; fixture-based regression test added)
- First `commands/` in the plugin: `/forward`, `/resume`, `/retrospective` (mandatory AI Diary + Honest Feedback, refuses otherwise)
- v2.11.0 across 4 manifests; tool count 30 at 3 doc sites; CHANGELOG

Server half: pitimon/memforge#711. Requires that server release deployed before these tools function.

## Test plan
- [x] `bun test` 138 pass / 0 fail (incl. new fixture + validation tests)
- [ ] Cross-QA against production after server deploy: /forward → /resume round trip, /retrospective type survival
- [ ] Tag v2.11.0 after merge + cross-QA

Closes #74