### PR TITLE
feat(hooks): proactive SessionStart context hook (Wave A) (#76)

### DIFF
--- a/.claude-plugin/CLAUDE.md
+++ b/.claude-plugin/CLAUDE.md
@@ -75,17 +75,32 @@ Set `"role": "admin"` in config to access admin features. Default is `"client"`.
 
 ## Sync (In-Process)
 
-Sync runs automatically inside the MCP server process — no separate daemon, hooks, or background processes.
+**Sync** runs automatically inside the MCP server process — no separate daemon or background process for syncing. (Context *retrieval* uses a read-only hook — see "Proactive Context Hooks" below; that is a separate concern from sync.)
 
 ### Architecture
 - `sync-poller.ts` - In-process polling of claude-mem SQLite (2s interval, configurable)
 - `remote-sync.ts` - HTTP sync via `POST /api/sync/push` with batch support
 - `pending-queue.ts` - In-memory retry queue (max 5 retries, lost on restart — server dedup handles overlap)
 
+## Proactive Context Hooks
+
+A read-only `SessionStart` hook (`src/hooks/session-context.ts`) injects a compact
+pointer to the latest handoff, open loops, and cross-project knowledge at session
+start, so server memory surfaces without an explicit `mem_search` / `mem_resume`
+call. Fail-open (any error → nothing injected, exit 0); pointer mode never injects
+raw next-steps (no stale-steering); non-redundant with claude-mem (which injects
+local recent observations).
+
+- Config (`~/.memforge/config.json`): `sessionContextEnabled` (default `true`),
+  `sessionContextMode` (`"pointer"` | `"full"`, default `"pointer"`),
+  `sessionContextMaxAgeDays` (default `30`).
+- Kill switch: `MEMFORGE_SESSION_CONTEXT=0`.
+
 ### Key Files
 | File | Purpose |
 |------|---------|
-| `~/.memforge/config.json` | Plugin configuration (API key, server URL, role, syncEnabled, pollInterval) |
+| `~/.memforge/config.json` | Plugin configuration (API key, server URL, role, syncEnabled, pollInterval, sessionContext*) |
+| `src/hooks/session-context.ts` | SessionStart context-injection hook (Wave A, #76) |
 
 ## Requirements
 

--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -1,3 +1,17 @@
 {
-  "hooks": {}
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "_R=\"$CLAUDE_PLUGIN_ROOT\"; [ -f \"$_R/src/hooks/session-context.ts\" ] || _R=\"$(ls -dt \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/pitimon-c-memforge/memforge-client/\"[0-9]*/ 2>/dev/null | head -1)\"; _R=\"${_R%/}\"; [ -f \"$_R/src/hooks/session-context.ts\" ] || _R=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/pitimon-c-memforge\"; [ -f \"$_R/src/hooks/session-context.ts\" ] || exit 0; export PATH=\"$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH\"; command -v bun >/dev/null 2>&1 || exit 0; exec bun \"$_R/src/hooks/session-context.ts\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the MemForge client plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2026-07-24
+
+### Added
+
+- **Proactive SessionStart context hook (Wave A)**
+  ([#76](https://github.com/pitimon/c-memforge/issues/76)). The plugin was
+  previously pull-only — server memory (handoff, open loops, cross-project)
+  surfaced only when an MCP tool was explicitly called. A new `SessionStart`
+  hook now injects a **compact pointer** at session start
+  (`Handoff #N (2d ago) · 3 open loops — run mem_resume for detail`) so that
+  continuity context is offered automatically. Reuses `callRemoteAPI` /
+  `formatResume`; adds `src/hooks/session-context.ts`.
+  - **Pointer mode (default)** injects counts + a hint, never the raw next-steps,
+    so a stale handoff cannot steer the model toward old work. Set
+    `sessionContextMode: "full"` to also inject the detailed resume block.
+  - **Fail-open**: any error / missing config / timeout → nothing injected,
+    exit 0. Never blocks or breaks a session.
+  - **Non-redundant with claude-mem**: injects the enrichment layer
+    (handoff / cross-project), never plain recent observations.
+  - Config: `sessionContextEnabled` (default `true`), `sessionContextMode`
+    (`"pointer"` | `"full"`, default `"pointer"`), `sessionContextMaxAgeDays`
+    (default `30`). Kill switch: `MEMFORGE_SESSION_CONTEXT=0`.
+  - Cross-project lookup gets a tighter 1.5s timeout so the graph traversal
+    never dominates session-start latency; resume gets 2.5s.
+
+### Changed
+
+- **`callRemoteAPI` accepts optional per-call `{ timeoutMs, maxRetries }`**
+  (backward-compatible — existing callers keep the 30s/60s + 2-retry defaults).
+  Hooks pass a short timeout + `maxRetries: 0` to bound wall-clock.
+
 ## [2.11.0] - 2026-07-06
 
 ### Added

--- a/config.example.json
+++ b/config.example.json
@@ -3,5 +3,8 @@
   "serverUrl": "https://memclaude.thaicloud.ai",
   "syncEnabled": true,
   "pollInterval": 2000,
-  "role": "client"
+  "role": "client",
+  "sessionContextEnabled": true,
+  "sessionContextMode": "pointer",
+  "sessionContextMaxAgeDays": 30
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/src/hooks/__tests__/session-context.test.ts
+++ b/src/hooks/__tests__/session-context.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the SessionStart context hook pure logic (memforge-client #76, Wave A).
+ *
+ * Only the pure functions are unit-tested; the I/O shell (stdin/exit/network) is
+ * validated by the offline dry-run in the PR. The contract these tests pin:
+ *  - empty / stale history → "" (nothing injected)
+ *  - POINTER output never contains the raw next-steps text (no stale-steering)
+ *  - kill switch + config defaults resolve correctly
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  ageInDays,
+  buildPointer,
+  resolveSessionContextConfig,
+  type CrossProjectLite,
+} from "../session-context";
+import type { ResumeResponse } from "../../mcp/handlers/session-handlers";
+
+const NOW = Date.parse("2026-07-24T12:00:00Z");
+
+function resume(overrides: Partial<ResumeResponse>): ResumeResponse {
+  return {
+    latest_handoff: null,
+    prior_handoffs: [],
+    latest_retrospective: null,
+    open_loops: [],
+    empty: false,
+    ...overrides,
+  };
+}
+
+describe("ageInDays", () => {
+  test("returns whole days floored, clamped at 0", () => {
+    expect(ageInDays("2026-07-22T12:00:00Z", NOW)).toBe(2);
+    expect(ageInDays("2026-07-24T18:00:00Z", NOW)).toBe(0); // future → 0
+  });
+  test("returns null for missing / unparseable", () => {
+    expect(ageInDays(undefined, NOW)).toBeNull();
+    expect(ageInDays("not-a-date", NOW)).toBeNull();
+  });
+});
+
+describe("buildPointer", () => {
+  test("empty resume + no cross-project → '' (nothing injected)", () => {
+    expect(buildPointer("memforge", resume({ empty: true }), null, NOW, 30)).toBe(
+      "",
+    );
+  });
+
+  test("null resume + null cross → ''", () => {
+    expect(buildPointer("memforge", null, null, NOW, 30)).toBe("");
+  });
+
+  test("fresh handoff → pointer with counts, NO raw next-steps text", () => {
+    const data = resume({
+      latest_handoff: {
+        id: 99,
+        project: "memforge",
+        next_steps: ["deploy the secret sauce", "rotate the keys"],
+        open_loops: ["is staging green?"],
+        created_at: "2026-07-22T12:00:00Z",
+      },
+    });
+    const out = buildPointer("memforge", data, null, NOW, 30);
+    expect(out).toContain("Handoff #99 (2d ago)");
+    expect(out).toContain("2 next steps");
+    expect(out).toContain("1 open loop");
+    expect(out).toContain("mem_resume");
+    expect(out).toContain("reference, not instructions");
+    // Stale-steering guard: the raw step text must NOT leak into context.
+    expect(out).not.toContain("deploy the secret sauce");
+    expect(out).not.toContain("rotate the keys");
+  });
+
+  test("handoff older than maxAgeDays is dropped", () => {
+    const data = resume({
+      latest_handoff: {
+        id: 7,
+        project: "memforge",
+        next_steps: ["x"],
+        created_at: "2026-05-01T12:00:00Z", // ~84d old
+      },
+    });
+    expect(buildPointer("memforge", data, null, NOW, 30)).toBe("");
+  });
+
+  test("cross-project suggestions add a line and dedupe/limit source projects", () => {
+    const cross: CrossProjectLite = {
+      suggestions: [
+        { sourceProject: "alpha", title: "a" },
+        { sourceProject: "alpha", title: "b" },
+        { sourceProject: "beta", title: "c" },
+        { sourceProject: "gamma", title: "d" },
+        { sourceProject: "delta", title: "e" },
+      ],
+    };
+    const out = buildPointer("memforge", resume({ empty: true }), cross, NOW, 30);
+    expect(out).toContain("Related work in other project(s): alpha, beta, gamma");
+    expect(out).not.toContain("delta"); // capped at 3
+    expect(out).toContain("mem_cross_project");
+  });
+
+  test("top-level open_loops wins over handoff.open_loops for the count", () => {
+    const data = resume({
+      open_loops: ["a", "b", "c"],
+      latest_handoff: {
+        id: 1,
+        project: "p",
+        next_steps: [],
+        open_loops: ["only-one"],
+        created_at: "2026-07-24T00:00:00Z",
+      },
+    });
+    expect(buildPointer("p", data, null, NOW, 30)).toContain("3 open loops");
+  });
+});
+
+describe("resolveSessionContextConfig", () => {
+  test("kill switch MEMFORGE_SESSION_CONTEXT=0 disables", () => {
+    expect(
+      resolveSessionContextConfig({ MEMFORGE_SESSION_CONTEXT: "0" }).enabled,
+    ).toBe(false);
+  });
+  test("defaults: enabled + pointer + 30d when no config present", () => {
+    // No ~/.memforge/config.json field set → getPluginConfig may return null.
+    const cfg = resolveSessionContextConfig({});
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.mode).toBe("pointer");
+    expect(cfg.maxAgeDays).toBe(30);
+  });
+});

--- a/src/hooks/session-context.ts
+++ b/src/hooks/session-context.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env bun
+/**
+ * SessionStart context hook (Wave A) — memforge-client #76.
+ *
+ * Injects a compact POINTER to the latest handoff + open loops + cross-project
+ * knowledge so MemForge *server* memory surfaces automatically at session start
+ * (the client was previously pull-only: server memory appeared only on an
+ * explicit mem_search / mem_resume call).
+ *
+ * Design contract (see PR #76):
+ *  - FAIL-OPEN: any error / missing config / timeout → emit nothing, exit 0.
+ *    A memory hook must never block or break a session.
+ *  - POINTER mode (default): inject counts + a "run mem_resume" hint, NOT the raw
+ *    next-steps — so a stale handoff cannot steer the model toward old work.
+ *  - Non-redundant with claude-mem: injects handoff / open-loops / cross-project
+ *    (the enrichment layer), never plain recent observations (claude-mem owns those).
+ *  - process.exit(0) is explicit: an abandoned fetch keeps Bun's event loop alive
+ *    up to the request timeout, so we must not rely on natural exit.
+ */
+
+import { basename } from "path";
+import {
+  initializeApiKey,
+  isRemoteEnabled,
+  callRemoteAPI,
+  getPluginConfig,
+} from "../mcp/api-client";
+import {
+  formatResume,
+  type ResumeResponse,
+} from "../mcp/handlers/session-handlers";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested — see __tests__/session-context.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Minimal shape we read from GET /context/cross-project (see context-handlers). */
+export interface CrossProjectLite {
+  suggestions?: Array<{ sourceProject?: string; title?: string }>;
+}
+
+/** Resolved Wave A config with defaults + env kill switch applied. */
+export interface SessionContextConfig {
+  enabled: boolean;
+  mode: "pointer" | "full";
+  maxAgeDays: number;
+}
+
+/** Read config, apply defaults + `MEMFORGE_SESSION_CONTEXT=0` kill switch. */
+export function resolveSessionContextConfig(
+  env: NodeJS.ProcessEnv,
+): SessionContextConfig {
+  if (env.MEMFORGE_SESSION_CONTEXT === "0") {
+    return { enabled: false, mode: "pointer", maxAgeDays: 30 };
+  }
+  const c = getPluginConfig();
+  return {
+    enabled: c?.sessionContextEnabled !== false, // default true
+    mode: c?.sessionContextMode === "full" ? "full" : "pointer",
+    maxAgeDays:
+      typeof c?.sessionContextMaxAgeDays === "number" &&
+      c.sessionContextMaxAgeDays > 0
+        ? c.sessionContextMaxAgeDays
+        : 30,
+  };
+}
+
+/** Whole days between an ISO timestamp and `now` (floored, >= 0); null if unparseable. */
+export function ageInDays(iso: string | undefined, now: number): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return Math.max(0, Math.floor((now - t) / 86_400_000));
+}
+
+/**
+ * Build the SessionStart pointer block. Returns "" when there is nothing worth
+ * injecting (no handoff within maxAgeDays AND no cross-project suggestions) —
+ * the caller then emits no output at all.
+ */
+export function buildPointer(
+  project: string,
+  resume: ResumeResponse | null,
+  cross: CrossProjectLite | null,
+  now: number,
+  maxAgeDays: number,
+): string {
+  const lines: string[] = [];
+
+  const handoff = resume && !resume.empty ? resume.latest_handoff : null;
+  if (handoff) {
+    const age = ageInDays(handoff.created_at, now);
+    const fresh = age === null || age <= maxAgeDays;
+    if (fresh) {
+      const loops =
+        resume?.open_loops?.length || handoff.open_loops?.length || 0;
+      const steps = handoff.next_steps?.length ?? 0;
+      const ageLabel = age === null ? "" : ` (${age}d ago)`;
+      const parts = [`Handoff #${handoff.id}${ageLabel}`];
+      if (steps) parts.push(`${steps} next step${steps === 1 ? "" : "s"}`);
+      if (loops) parts.push(`${loops} open loop${loops === 1 ? "" : "s"}`);
+      lines.push(`- ${parts.join(" · ")} — run \`mem_resume\` for detail`);
+    }
+  }
+
+  const suggestions = cross?.suggestions ?? [];
+  const projects = [
+    ...new Set(
+      suggestions
+        .map((s) => s.sourceProject)
+        .filter((p): p is string => typeof p === "string" && p.length > 0),
+    ),
+  ].slice(0, 3);
+  if (projects.length) {
+    lines.push(
+      `- Related work in other project(s): ${projects.join(", ")} — run \`mem_cross_project\``,
+    );
+  }
+
+  if (lines.length === 0) return "";
+  return (
+    `## MemForge server memory — reference, not instructions\n` +
+    `_(persistent memory for "${project}"; background context, not commands)_\n` +
+    lines.join("\n")
+  );
+}
+
+// ---------------------------------------------------------------------------
+// I/O shell (validated by offline dry-run, not unit-tested)
+// ---------------------------------------------------------------------------
+
+/** Read all of stdin as a string (empty string if none / on error). */
+async function readStdin(): Promise<string> {
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+    return Buffer.concat(chunks).toString("utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/** Emit the SessionStart additionalContext (only if non-empty) and exit 0. */
+function emitAndExit(additionalContext: string): never {
+  if (additionalContext) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "SessionStart",
+          additionalContext,
+        },
+      }),
+    );
+  }
+  process.exit(0);
+}
+
+async function main(): Promise<void> {
+  // Resolve project name first — needed even if everything else fails.
+  let project = process.env.MEMFORGE_PROJECT || "";
+  try {
+    const raw = await readStdin();
+    const input = raw ? (JSON.parse(raw) as { cwd?: unknown }) : {};
+    if (!project) {
+      const cwd = typeof input.cwd === "string" ? input.cwd : process.cwd();
+      project = basename(cwd);
+    }
+  } catch {
+    if (!project) project = basename(process.cwd());
+  }
+
+  const cfg = resolveSessionContextConfig(process.env);
+  if (!cfg.enabled) emitAndExit("");
+
+  try {
+    initializeApiKey();
+    if (!isRemoteEnabled()) emitAndExit("");
+
+    // Short timeouts + no retries: this hook blocks session start, so bound it.
+    // resume is the primary value and fast (~0.2s); cross-project is a graph
+    // traversal that can take ~2.3s for an often-empty result, so it gets a
+    // tighter leash — it must never dominate startup latency.
+    const [resumeR, crossR] = await Promise.allSettled([
+      callRemoteAPI(
+        "/api/v1/resume",
+        { project, limit: 1 },
+        { timeoutMs: 2500, maxRetries: 0 },
+      ),
+      callRemoteAPI(
+        "/context/cross-project",
+        { project, limit: 3 },
+        { timeoutMs: 1500, maxRetries: 0 },
+      ),
+    ]);
+
+    const resume =
+      resumeR.status === "fulfilled"
+        ? (resumeR.value as ResumeResponse)
+        : null;
+    const cross =
+      crossR.status === "fulfilled"
+        ? (crossR.value as CrossProjectLite)
+        : null;
+
+    const pointer = buildPointer(
+      project,
+      resume,
+      cross,
+      Date.now(),
+      cfg.maxAgeDays,
+    );
+
+    // "full" mode (opt-in): append the detailed resume block below the pointer,
+    // but only when there is real history — formatResume's empty-state text
+    // ("No handoff history… run mem_handoff") must never be auto-injected.
+    if (cfg.mode === "full" && resume && !resume.empty) {
+      const detail = formatResume(project, resume);
+      emitAndExit(pointer ? `${pointer}\n\n${detail}` : detail);
+    }
+
+    emitAndExit(pointer);
+  } catch (err) {
+    process.stderr.write(
+      `[memforge] session-context hook failed (non-fatal): ${
+        (err as Error)?.message ?? String(err)
+      }\n`,
+    );
+    emitAndExit("");
+  }
+}
+
+main();

--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -43,6 +43,13 @@ interface PluginConfig {
   syncEnabled?: boolean;
   pollInterval?: number;
   role?: "client" | "admin";
+  // Proactive context hooks (#76). All optional — hooks apply their own defaults.
+  sessionContextEnabled?: boolean; // Wave A SessionStart hook (default: true)
+  sessionContextMode?: "pointer" | "full"; // default: "pointer"
+  sessionContextMaxAgeDays?: number; // hide handoffs older than this (default: 30)
+  promptContextEnabled?: boolean; // Wave B UserPromptSubmit RAG hook (default: false)
+  promptRelevanceThreshold?: number; // min score to inject (Wave B)
+  promptContextTimeoutMs?: number; // per-prompt search timeout (Wave B)
 }
 
 /**
@@ -70,6 +77,15 @@ function loadPluginConfig(): PluginConfig | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Public, fresh read of the plugin config (or null if absent/unparseable).
+ * Used by the context hooks to read their opt-in toggles without coupling to
+ * MCP-server startup. Fail-open: returns null on any error.
+ */
+export function getPluginConfig(): Readonly<PluginConfig> | null {
+  return loadPluginConfig();
 }
 
 /** Initialize API key from plugin config or fallback to claude-mem settings */
@@ -342,17 +358,29 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Per-call overrides for callRemoteAPI (all optional, backward-compatible) */
+export interface CallOptions {
+  /** Override the request timeout (ms). Default: search endpoints 60s, else 30s. */
+  timeoutMs?: number;
+  /** Override the max transient-error retries. Default: MAX_RETRIES (2). Use 0 for hooks. */
+  maxRetries?: number;
+}
+
 /**
  * Call Remote API with timeout and retry for transient errors.
  *
  * @param endpoint - Local endpoint name (e.g., '/search')
  * @param params - Query parameters
+ * @param opts - Optional per-call timeout/retry overrides (hooks pass a short
+ *   timeout + maxRetries:0 to bound wall-clock; existing callers omit this and
+ *   keep the original 30s/60s + 2-retry behavior).
  * @returns Promise resolving to API response data
  * @throws Error if remote not configured or API error
  */
 export async function callRemoteAPI(
   endpoint: string,
   params: Record<string, unknown>,
+  opts: CallOptions = {},
 ): Promise<unknown> {
   if (!isRemoteEnabled()) {
     throw new Error("Remote search not configured");
@@ -362,7 +390,9 @@ export async function callRemoteAPI(
   const isSearchEndpoint =
     ["/hybrid", "/vector", "/search"].includes(endpoint) ||
     endpoint.includes("/search");
-  const timeout = isSearchEndpoint ? SEARCH_TIMEOUT_MS : REMOTE_TIMEOUT_MS;
+  const timeout =
+    opts.timeoutMs ?? (isSearchEndpoint ? SEARCH_TIMEOUT_MS : REMOTE_TIMEOUT_MS);
+  const maxRetries = opts.maxRetries ?? MAX_RETRIES;
 
   const remoteEndpoint = resolveEndpoint(endpoint);
 
@@ -376,9 +406,13 @@ export async function callRemoteAPI(
   const url = `${remoteApiUrl}${remoteEndpoint}?${searchParams}`;
   let lastError: unknown;
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (attempt > 0) {
-      await sleep(RETRY_DELAYS_MS[attempt - 1]);
+      // Clamp to the last known delay if maxRetries exceeds the delay table.
+      const delay =
+        RETRY_DELAYS_MS[attempt - 1] ??
+        RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
+      await sleep(delay);
     }
 
     const controller = new AbortController();
@@ -397,7 +431,7 @@ export async function callRemoteAPI(
       return await response.json();
     } catch (error) {
       lastError = error;
-      if (!isRetryableError(error) || attempt === MAX_RETRIES) {
+      if (!isRetryableError(error) || attempt === maxRetries) {
         throw error;
       }
     } finally {


### PR DESCRIPTION
Closes #76 (Wave A).

## Why
c-memforge was **pull-only** — server memory (handoff, open loops, cross-project) surfaced only on an explicit `mem_search`/`mem_resume` call. Root cause: `.claude-plugin/hooks/hooks.json` was `{"hooks": {}}`. The session-start context users saw came from **claude-mem** (local recent obs), not c-memforge's enriched server layer.

## What (Wave A — SessionStart pointer)
- New read-only `SessionStart` hook `src/hooks/session-context.ts` injects a **compact pointer**: `Handoff #N (2d ago) · 3 open loops — run mem_resume for detail` + a cross-project line.
- **Pointer mode (default)** injects counts + a hint, **never the raw next-steps** → a stale handoff can't steer the model toward old work. `sessionContextMode: "full"` opts into the detailed `formatResume` block.
- **Fail-open**: any error / missing config / timeout → nothing injected, `exit 0`. Never blocks a session.
- **Non-redundant with claude-mem**: injects the enrichment layer (handoff / cross-project), never plain recent observations.
- `callRemoteAPI` gains optional `{ timeoutMs, maxRetries }` (backward-compatible); hook passes short timeouts + `maxRetries: 0`. Cross-project capped at 1.5s (graph traversal ~2.3s), resume 2.5s.
- Bash resolver in hooks.json mirrors `.mcp.json` root resolution and matches **claude-mem's proven bash-hook** approach (claude-mem is already a hard dependency, so no new platform constraint).

## Config
`sessionContextEnabled` (default true) · `sessionContextMode` (`pointer`|`full`, default `pointer`) · `sessionContextMaxAgeDays` (default 30). Kill switch: `MEMFORGE_SESSION_CONTEXT=0`.

## Deferred — Wave B (per-prompt RAG)
Held behind a **value-measurement gate**: measure Wave A's non-redundancy vs claude-mem + token delta in real sessions before building the higher-cost UserPromptSubmit RAG hook. May prove unnecessary if the pointer alone cures the passive-recall complaint.

## Conflict analysis (verified)
Checked every installed plugin's hooks.json. Claude Code hooks **stack** (no collision). Wave A is non-redundant with claude-mem (handoff/cross-project don't exist in its local injection). Data flow: c-memforge syncs claude-mem local→server then enriches → server ⊇ local, so Wave A excludes recent-obs.

## Test plan
- `bun test` → 148 pass, 0 fail (10 new: `buildPointer` empty→'', age-cutoff, dedup/cap, kill switch, config defaults).
- Offline dry-run: exit 0, empty, no hang, <3s.
- End-to-end bash→bun→hook via resolver: exit 0, 1.53s online; fail-open on unresolvable root.
- Typecheck: 0 new errors (1 pre-existing `mcp-server.ts` SDK-drift error unrelated).

Reviewed independently by Fable — all 6 findings folded in (timeout param, bootstrap resolver, dedup mechanism, formatResume wrapping, shared-state hygiene, trust-model header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)