### PR TITLE
feat(hooks): Wave A telemetry for the Wave B go/no-go gate (v2.13.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "memforge-client",
       "description": "MemForge - Persistent memory for Claude Code (SaaS client)",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "author": {
         "name": "Pitimon",
         "email": "pitimon@thaicloud.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "memforge-client",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "MemForge - Persistent memory for Claude Code (SaaS client)"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the MemForge client plugin are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0] - 2026-07-24
+
+### Added
+
+- **Wave A hook telemetry — Wave B go/no-go gate instrumentation**
+  ([#76](https://github.com/pitimon/c-memforge/issues/76)). Wave B (per-prompt
+  `UserPromptSubmit` RAG) is held behind a value-measurement gate: does the
+  Wave A pointer *alone* close the passive-memory gap? The SessionStart hook now
+  appends **one JSONL line per active run** so that question can be answered from
+  real sessions instead of guesswork. Adds `src/hooks/metrics-logger.ts` and
+  `scripts/wave-metrics-report.ts`.
+  - **Signals captured**: emission rate (`emitted`), injected token cost
+    (`chars` / `tokens_est`), which content types fired
+    (`has_handoff` / `has_cross_project` — the non-redundant-vs-claude-mem
+    layer), and fetch latency (`resume_ms` / `cross_ms` / `total_ms`, which
+    validates the 2.5s / 1.5s timeout budget).
+  - **Fail-open**, identical to the hook itself — a telemetry write failure is
+    silently swallowed and never blocks or breaks a session.
+  - **Kill switch** `MEMFORGE_METRICS=0`; path override `MEMFORGE_METRICS_FILE`
+    (default `~/.claude/c-memforge-metrics.jsonl`, honoring `CLAUDE_CONFIG_DIR`).
+  - Aggregate with `bun scripts/wave-metrics-report.ts` — prints emission rate,
+    token percentiles, content-type breakdown, and latency percentiles. The
+    behavioral "was the pointer useful" signal is a manual tally kept alongside.
+
 ## [2.12.0] - 2026-07-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memforge-client",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "MemForge client plugin for Claude Code - persistent semantic memory",
   "type": "module",
   "scripts": {

--- a/scripts/wave-metrics-report.ts
+++ b/scripts/wave-metrics-report.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+/**
+ * Aggregate Wave A hook telemetry for the Wave B go/no-go gate.
+ *
+ * Usage:  bun scripts/wave-metrics-report.ts [path-to-metrics.jsonl]
+ * Default path resolves the same way the hook writes it
+ * (MEMFORGE_METRICS_FILE → CLAUDE_CONFIG_DIR → ~/.claude/c-memforge-metrics.jsonl).
+ *
+ * Reports the objective gate signals; the behavioral "usefulness" signal is a
+ * manual tally kept alongside (see CHANGELOG 2.13.0 / issue #76).
+ */
+
+import { readFileSync } from "fs";
+import { resolveMetricsPath, type MetricRecord } from "../src/hooks/metrics-logger";
+
+const path = process.argv[2] || resolveMetricsPath(process.env);
+
+let raw: string;
+try {
+  raw = readFileSync(path, "utf-8");
+} catch {
+  console.error(`No metrics file at ${path} — hook has not run yet (or metrics disabled).`);
+  process.exit(1);
+}
+
+const recs: MetricRecord[] = raw
+  .split("\n")
+  .filter(Boolean)
+  .map((l) => {
+    try {
+      return JSON.parse(l) as MetricRecord;
+    } catch {
+      return null;
+    }
+  })
+  .filter((r): r is MetricRecord => r !== null);
+
+const n = recs.length;
+if (n === 0) {
+  console.error(`Metrics file ${path} has no parseable records yet.`);
+  process.exit(1);
+}
+
+const pct = (arr: number[], p: number): number =>
+  arr.length ? arr[Math.min(arr.length - 1, Math.floor(p * arr.length))]! : 0;
+
+const emitted = recs.filter((r) => r.emitted);
+const errors = recs.filter((r) => r.error).length;
+const withHandoff = recs.filter((r) => r.has_handoff).length;
+const withCross = recs.filter((r) => r.has_cross_project).length;
+const tokens = emitted.map((r) => r.tokens_est).sort((a, b) => a - b);
+const totalMs = recs.map((r) => r.total_ms).sort((a, b) => a - b);
+const projects = new Set(recs.map((r) => r.project));
+
+const rate = (k: number) => `${((100 * k) / n).toFixed(0)}% (${k}/${n})`;
+
+console.log(`Wave A hook telemetry — ${path}`);
+console.log(`  runs=${n}  projects=${projects.size}  errors=${errors}`);
+console.log(`  emission_rate = ${rate(emitted.length)}`);
+console.log(`  with_handoff  = ${rate(withHandoff)}`);
+console.log(`  with_cross    = ${rate(withCross)}`);
+console.log(
+  `  pointer_tokens (emitted only): p50=${pct(tokens, 0.5)} p90=${pct(tokens, 0.9)} max=${tokens[tokens.length - 1] ?? 0}`,
+);
+console.log(
+  `  total_ms: p50=${pct(totalMs, 0.5)} p90=${pct(totalMs, 0.9)} max=${totalMs[totalMs.length - 1] ?? 0}`,
+);
+console.log("");
+console.log("Gate read: low emission_rate OR pointer already covers the need → Wave B likely unnecessary.");
+console.log("           frequent emission BUT residual per-prompt gaps (manual tally) → build Wave B.");

--- a/src/hooks/__tests__/metrics-logger.test.ts
+++ b/src/hooks/__tests__/metrics-logger.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for Wave A hook telemetry (metrics-logger).
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  buildMetricRecord,
+  resolveMetricsPath,
+  metricsEnabled,
+  appendMetric,
+  type MetricInput,
+} from "../metrics-logger";
+
+const NOW = Date.parse("2026-07-24T12:00:00.000Z");
+
+function baseInput(overrides: Partial<MetricInput> = {}): MetricInput {
+  return {
+    now: NOW,
+    project: "memforge",
+    mode: "pointer",
+    additionalContext: "",
+    hasHandoff: false,
+    handoffAgeDays: null,
+    openLoops: 0,
+    nextSteps: 0,
+    hasCrossProject: false,
+    resumeOk: true,
+    crossOk: true,
+    resumeMs: 200,
+    crossMs: 300,
+    totalMs: 320,
+    ...overrides,
+  };
+}
+
+describe("buildMetricRecord", () => {
+  test("emitted=false + zero tokens when additionalContext is empty", () => {
+    const rec = buildMetricRecord(baseInput({ additionalContext: "" }));
+    expect(rec.emitted).toBe(false);
+    expect(rec.chars).toBe(0);
+    expect(rec.tokens_est).toBe(0);
+  });
+
+  test("emitted=true + token estimate rounds up chars/4", () => {
+    const rec = buildMetricRecord(
+      baseInput({ additionalContext: "x".repeat(10) }),
+    );
+    expect(rec.emitted).toBe(true);
+    expect(rec.chars).toBe(10);
+    expect(rec.tokens_est).toBe(3); // ceil(10/4)
+  });
+
+  test("passes through handoff / cross-project facts", () => {
+    const rec = buildMetricRecord(
+      baseInput({
+        additionalContext: "pointer",
+        hasHandoff: true,
+        handoffAgeDays: 2,
+        openLoops: 3,
+        nextSteps: 4,
+        hasCrossProject: true,
+      }),
+    );
+    expect(rec.has_handoff).toBe(true);
+    expect(rec.handoff_age_days).toBe(2);
+    expect(rec.open_loops).toBe(3);
+    expect(rec.next_steps).toBe(4);
+    expect(rec.has_cross_project).toBe(true);
+  });
+
+  test("ts is derived from the injected now (no wall-clock dependency)", () => {
+    const rec = buildMetricRecord(baseInput());
+    expect(rec.ts).toBe("2026-07-24T12:00:00.000Z");
+  });
+
+  test("error is truncated to 200 chars and omitted when absent", () => {
+    const clean = buildMetricRecord(baseInput());
+    expect(clean.error).toBeUndefined();
+    const noisy = buildMetricRecord(
+      baseInput({ error: "e".repeat(500) }),
+    );
+    expect(noisy.error?.length).toBe(200);
+  });
+});
+
+describe("resolveMetricsPath", () => {
+  test("MEMFORGE_METRICS_FILE wins", () => {
+    expect(resolveMetricsPath({ MEMFORGE_METRICS_FILE: "/tmp/m.jsonl" })).toBe(
+      "/tmp/m.jsonl",
+    );
+  });
+
+  test("falls back to CLAUDE_CONFIG_DIR", () => {
+    expect(resolveMetricsPath({ CLAUDE_CONFIG_DIR: "/cfg" })).toBe(
+      join("/cfg", "c-memforge-metrics.jsonl"),
+    );
+  });
+
+  test("defaults under ~/.claude", () => {
+    const p = resolveMetricsPath({});
+    expect(p.endsWith(join(".claude", "c-memforge-metrics.jsonl"))).toBe(true);
+  });
+});
+
+describe("metricsEnabled", () => {
+  test("disabled only when explicitly '0'", () => {
+    expect(metricsEnabled({ MEMFORGE_METRICS: "0" })).toBe(false);
+    expect(metricsEnabled({ MEMFORGE_METRICS: "1" })).toBe(true);
+    expect(metricsEnabled({})).toBe(true);
+  });
+});
+
+describe("appendMetric", () => {
+  const tmpFile = join(tmpdir(), `cmemforge-metrics-test-${process.pid}.jsonl`);
+
+  afterEach(() => {
+    if (existsSync(tmpFile)) rmSync(tmpFile);
+  });
+
+  test("appends one JSON line per call", () => {
+    const rec = buildMetricRecord(baseInput({ additionalContext: "abc" }));
+    appendMetric(rec, tmpFile);
+    appendMetric(rec, tmpFile);
+    const lines = readFileSync(tmpFile, "utf-8").split("\n").filter(Boolean);
+    expect(lines.length).toBe(2);
+    expect(JSON.parse(lines[0]!).chars).toBe(3);
+  });
+
+  test("fail-open: unwritable path does not throw", () => {
+    const rec = buildMetricRecord(baseInput());
+    expect(() =>
+      appendMetric(rec, "/nonexistent-dir-xyz/deep/metrics.jsonl"),
+    ).not.toThrow();
+  });
+});

--- a/src/hooks/__tests__/session-context.test.ts
+++ b/src/hooks/__tests__/session-context.test.ts
@@ -12,6 +12,7 @@ import { describe, test, expect } from "bun:test";
 import {
   ageInDays,
   buildPointer,
+  composeContext,
   resolveSessionContextConfig,
   type CrossProjectLite,
 } from "../session-context";
@@ -38,6 +39,43 @@ describe("ageInDays", () => {
   test("returns null for missing / unparseable", () => {
     expect(ageInDays(undefined, NOW)).toBeNull();
     expect(ageInDays("not-a-date", NOW)).toBeNull();
+  });
+});
+
+describe("composeContext", () => {
+  test("pointer mode → returns the pointer unchanged", () => {
+    expect(
+      composeContext("memforge", "pointer", "PTR", resume({ empty: false })),
+    ).toBe("PTR");
+  });
+
+  test("full mode + empty resume → pointer only (never inject empty-state)", () => {
+    expect(
+      composeContext("memforge", "full", "PTR", resume({ empty: true })),
+    ).toBe("PTR");
+    expect(composeContext("memforge", "full", "PTR", null)).toBe("PTR");
+  });
+
+  test("full mode + real history → pointer + detail block", () => {
+    const out = composeContext(
+      "memforge",
+      "full",
+      "PTR",
+      resume({ latest_handoff: null, empty: false, open_loops: [] }),
+    );
+    expect(out.startsWith("PTR\n\n")).toBe(true);
+    expect(out.length).toBeGreaterThan("PTR\n\n".length);
+  });
+
+  test("full mode + real history + empty pointer → detail only (no leading blank)", () => {
+    const out = composeContext(
+      "memforge",
+      "full",
+      "",
+      resume({ empty: false }),
+    );
+    expect(out.startsWith("\n")).toBe(false);
+    expect(out.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/hooks/metrics-logger.ts
+++ b/src/hooks/metrics-logger.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+/**
+ * Wave A hook telemetry — Wave B gate instrumentation (memforge-client #76).
+ *
+ * Appends ONE JSONL line per active SessionStart-hook run so we can measure,
+ * over a real soak window, whether the Wave A pointer alone closes the passive-
+ * memory gap (→ Wave B unnecessary) or leaves a residual gap (→ build Wave B).
+ *
+ * Gate signals captured: emission rate, injected token cost, which content
+ * types fired (handoff / cross-project = the non-redundant-vs-claude-mem layer),
+ * and fetch latency (validates the 2.5s/1.5s timeout budget).
+ *
+ * Contract: FAIL-OPEN, identical to the hook itself. Nothing here may throw,
+ * block, or break a session — a telemetry failure is silently swallowed.
+ * Kill switch: MEMFORGE_METRICS=0. Path override: MEMFORGE_METRICS_FILE.
+ */
+
+import { appendFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+/** One line of telemetry. Flat + JSON-serializable for easy aggregation. */
+export interface MetricRecord {
+  ts: string;
+  project: string;
+  mode: "pointer" | "full";
+  emitted: boolean;
+  chars: number;
+  tokens_est: number;
+  has_handoff: boolean;
+  handoff_age_days: number | null;
+  open_loops: number;
+  next_steps: number;
+  has_cross_project: boolean;
+  resume_ok: boolean;
+  cross_ok: boolean;
+  resume_ms: number;
+  cross_ms: number;
+  total_ms: number;
+  error?: string;
+}
+
+/** Resolved hook state fed into buildMetricRecord (keeps the builder pure). */
+export interface MetricInput {
+  now: number;
+  project: string;
+  mode: "pointer" | "full";
+  additionalContext: string;
+  hasHandoff: boolean;
+  handoffAgeDays: number | null;
+  openLoops: number;
+  nextSteps: number;
+  hasCrossProject: boolean;
+  resumeOk: boolean;
+  crossOk: boolean;
+  resumeMs: number;
+  crossMs: number;
+  totalMs: number;
+  error?: string;
+}
+
+/** Pure — build the metric record from resolved hook state (unit-tested). */
+export function buildMetricRecord(input: MetricInput): MetricRecord {
+  const chars = input.additionalContext.length;
+  const rec: MetricRecord = {
+    ts: new Date(input.now).toISOString(),
+    project: input.project,
+    mode: input.mode,
+    emitted: chars > 0,
+    chars,
+    tokens_est: Math.ceil(chars / 4),
+    has_handoff: input.hasHandoff,
+    handoff_age_days: input.handoffAgeDays,
+    open_loops: input.openLoops,
+    next_steps: input.nextSteps,
+    has_cross_project: input.hasCrossProject,
+    resume_ok: input.resumeOk,
+    cross_ok: input.crossOk,
+    resume_ms: input.resumeMs,
+    cross_ms: input.crossMs,
+    total_ms: input.totalMs,
+  };
+  if (input.error) rec.error = input.error.slice(0, 200);
+  return rec;
+}
+
+/** Resolve the metrics file path (env override → CLAUDE_CONFIG_DIR → ~/.claude). */
+export function resolveMetricsPath(env: NodeJS.ProcessEnv): string {
+  if (env.MEMFORGE_METRICS_FILE) return env.MEMFORGE_METRICS_FILE;
+  const base = env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  return join(base, "c-memforge-metrics.jsonl");
+}
+
+/** True unless the metrics kill switch (MEMFORGE_METRICS=0) is set. */
+export function metricsEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env.MEMFORGE_METRICS !== "0";
+}
+
+/** Fail-open append of one JSONL line. Never throws. */
+export function appendMetric(record: MetricRecord, path: string): void {
+  try {
+    appendFileSync(path, JSON.stringify(record) + "\n");
+  } catch {
+    // Telemetry must never break the hook.
+  }
+}

--- a/src/hooks/session-context.ts
+++ b/src/hooks/session-context.ts
@@ -29,6 +29,13 @@ import {
   formatResume,
   type ResumeResponse,
 } from "../mcp/handlers/session-handlers";
+import {
+  appendMetric,
+  buildMetricRecord,
+  metricsEnabled,
+  resolveMetricsPath,
+  type MetricInput,
+} from "./metrics-logger";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (unit-tested — see __tests__/session-context.test.ts)
@@ -155,71 +162,198 @@ function emitAndExit(additionalContext: string): never {
   process.exit(0);
 }
 
-async function main(): Promise<void> {
-  // Resolve project name first — needed even if everything else fails.
-  let project = process.env.MEMFORGE_PROJECT || "";
+/** Per-call timing wrapper — never rejects, so Promise.all stays simple. */
+async function timeCall<T>(
+  p: Promise<T>,
+): Promise<{ ok: boolean; value: T | null; ms: number }> {
+  const s = Date.now();
   try {
-    const raw = await readStdin();
-    const input = raw ? (JSON.parse(raw) as { cwd?: unknown }) : {};
-    if (!project) {
-      const cwd = typeof input.cwd === "string" ? input.cwd : process.cwd();
-      project = basename(cwd);
-    }
+    return { ok: true, value: await p, ms: Date.now() - s };
   } catch {
-    if (!project) project = basename(process.cwd());
+    return { ok: false, value: null, ms: Date.now() - s };
   }
+}
 
-  const cfg = resolveSessionContextConfig(process.env);
-  if (!cfg.enabled) emitAndExit("");
+/** Latency the fetch took, plus per-call ok flags — all gate signals. */
+interface FetchTimings {
+  resumeOk: boolean;
+  crossOk: boolean;
+  resumeMs: number;
+  crossMs: number;
+  totalMs: number;
+}
 
-  try {
-    initializeApiKey();
-    if (!isRemoteEnabled()) emitAndExit("");
+interface FetchResult {
+  resume: ResumeResponse | null;
+  cross: CrossProjectLite | null;
+  timings: FetchTimings;
+}
 
-    // Short timeouts + no retries: this hook blocks session start, so bound it.
-    // resume is the primary value and fast (~0.2s); cross-project is a graph
-    // traversal that can take ~2.3s for an often-empty result, so it gets a
-    // tighter leash — it must never dominate startup latency.
-    const [resumeR, crossR] = await Promise.allSettled([
+/**
+ * Fetch resume + cross-project with short, no-retry timeouts (this hook blocks
+ * session start, so it must be bounded). resume is the primary value and fast
+ * (~0.2s); cross-project is a graph traversal that can take ~2.3s for an often-
+ * empty result, so it gets a tighter 1.5s leash — it must never dominate startup.
+ */
+async function fetchContext(project: string): Promise<FetchResult> {
+  const fetchStart = Date.now();
+  const [resumeR, crossR] = await Promise.all([
+    timeCall(
       callRemoteAPI(
         "/api/v1/resume",
         { project, limit: 1 },
         { timeoutMs: 2500, maxRetries: 0 },
       ),
+    ),
+    timeCall(
       callRemoteAPI(
         "/context/cross-project",
         { project, limit: 3 },
         { timeoutMs: 1500, maxRetries: 0 },
       ),
-    ]);
+    ),
+  ]);
+  return {
+    resume: resumeR.ok ? (resumeR.value as ResumeResponse) : null,
+    cross: crossR.ok ? (crossR.value as CrossProjectLite) : null,
+    timings: {
+      resumeOk: resumeR.ok,
+      crossOk: crossR.ok,
+      resumeMs: resumeR.ms,
+      crossMs: crossR.ms,
+      totalMs: Date.now() - fetchStart,
+    },
+  };
+}
 
-    const resume =
-      resumeR.status === "fulfilled"
-        ? (resumeR.value as ResumeResponse)
-        : null;
-    const cross =
-      crossR.status === "fulfilled"
-        ? (crossR.value as CrossProjectLite)
-        : null;
+/** Assemble the telemetry input for a successful run (pure — `now` injected). */
+function runMetricInput(
+  project: string,
+  mode: "pointer" | "full",
+  additionalContext: string,
+  { resume, cross, timings }: FetchResult,
+  now: number,
+): MetricInput {
+  const handoff = resume && !resume.empty ? resume.latest_handoff : null;
+  return {
+    now,
+    project,
+    mode,
+    additionalContext,
+    hasHandoff: !!handoff,
+    handoffAgeDays: handoff ? ageInDays(handoff.created_at, now) : null,
+    openLoops: resume?.open_loops?.length || handoff?.open_loops?.length || 0,
+    nextSteps: handoff?.next_steps?.length ?? 0,
+    hasCrossProject: (cross?.suggestions?.length ?? 0) > 0,
+    ...timings,
+  };
+}
 
+/** Assemble the telemetry input for a failed run (pure — `now` injected). */
+function errorMetricInput(
+  project: string,
+  mode: "pointer" | "full",
+  now: number,
+  err: unknown,
+): MetricInput {
+  return {
+    now,
+    project,
+    mode,
+    additionalContext: "",
+    hasHandoff: false,
+    handoffAgeDays: null,
+    openLoops: 0,
+    nextSteps: 0,
+    hasCrossProject: false,
+    resumeOk: false,
+    crossOk: false,
+    resumeMs: 0,
+    crossMs: 0,
+    totalMs: 0,
+    error: (err as Error)?.message ?? String(err),
+  };
+}
+
+/** Compose the injected context: pointer, or (in "full" mode) pointer + detail. */
+export function composeContext(
+  project: string,
+  mode: "pointer" | "full",
+  pointer: string,
+  resume: ResumeResponse | null,
+): string {
+  // "full" mode (opt-in) appends the detailed resume block below the pointer,
+  // but only when there is real history — formatResume's empty-state text
+  // ("No handoff history… run mem_handoff") must never be auto-injected.
+  if (mode !== "full" || !resume || resume.empty) return pointer;
+  const detail = formatResume(project, resume);
+  return pointer ? `${pointer}\n\n${detail}` : detail;
+}
+
+/**
+ * Resolve the project name: MEMFORGE_PROJECT wins, else the basename of the
+ * hook payload's cwd, else process.cwd(). Always drains stdin; never throws.
+ */
+async function resolveProject(): Promise<string> {
+  const preset = process.env.MEMFORGE_PROJECT || "";
+  try {
+    const raw = await readStdin();
+    if (preset) return preset;
+    const input = raw ? (JSON.parse(raw) as { cwd?: unknown }) : {};
+    const cwd = typeof input.cwd === "string" ? input.cwd : process.cwd();
+    return basename(cwd);
+  } catch {
+    return preset || basename(process.cwd());
+  }
+}
+
+async function main(): Promise<void> {
+  const project = await resolveProject();
+  const cfg = resolveSessionContextConfig(process.env);
+  if (!cfg.enabled) emitAndExit("");
+
+  // Wave B gate telemetry (fail-open, kill switch MEMFORGE_METRICS=0). Resolved
+  // up front so both the success and catch paths can log a single JSONL line.
+  const collectMetrics = metricsEnabled(process.env);
+  const metricsPath = resolveMetricsPath(process.env);
+
+  try {
+    initializeApiKey();
+    if (!isRemoteEnabled()) emitAndExit("");
+
+    const result = await fetchContext(project);
+    const now = Date.now();
     const pointer = buildPointer(
       project,
-      resume,
-      cross,
-      Date.now(),
+      result.resume,
+      result.cross,
+      now,
       cfg.maxAgeDays,
     );
+    const additionalContext = composeContext(
+      project,
+      cfg.mode,
+      pointer,
+      result.resume,
+    );
 
-    // "full" mode (opt-in): append the detailed resume block below the pointer,
-    // but only when there is real history — formatResume's empty-state text
-    // ("No handoff history… run mem_handoff") must never be auto-injected.
-    if (cfg.mode === "full" && resume && !resume.empty) {
-      const detail = formatResume(project, resume);
-      emitAndExit(pointer ? `${pointer}\n\n${detail}` : detail);
+    if (collectMetrics) {
+      appendMetric(
+        buildMetricRecord(
+          runMetricInput(project, cfg.mode, additionalContext, result, now),
+        ),
+        metricsPath,
+      );
     }
 
-    emitAndExit(pointer);
+    emitAndExit(additionalContext);
   } catch (err) {
+    if (collectMetrics) {
+      appendMetric(
+        buildMetricRecord(errorMetricInput(project, cfg.mode, Date.now(), err)),
+        metricsPath,
+      );
+    }
     process.stderr.write(
       `[memforge] session-context hook failed (non-fatal): ${
         (err as Error)?.message ?? String(err)


### PR DESCRIPTION
## What & why

Wave B (per-prompt `UserPromptSubmit` RAG) is held behind a **value-measurement gate**: does the Wave A SessionStart pointer *alone* close the passive-memory gap (→ Wave B unnecessary), or is there a residual per-prompt gap (→ build Wave B)? Until now the hook emitted a pointer but **logged nothing**, so zero gate data was being collected. This instruments it.

Refs #76.

## Signals captured (one JSONL line per active run)

- **Emission rate** — `emitted` (did a pointer fire this session?)
- **Token cost** — `chars` / `tokens_est` (cost of the injection)
- **Non-redundancy vs claude-mem** — `has_handoff` / `has_cross_project` (the enrichment layer claude-mem doesn't provide)
- **Latency** — `resume_ms` / `cross_ms` / `total_ms` (validates the 2.5s / 1.5s timeout budget)

The behavioral "was the pointer useful" signal is a manual tally kept alongside.

## Changes

- **`src/hooks/metrics-logger.ts`** (new) — pure `buildMetricRecord` + fail-open `appendMetric`. Kill switch `MEMFORGE_METRICS=0`; path override `MEMFORGE_METRICS_FILE` (default `~/.claude/c-memforge-metrics.jsonl`, honors `CLAUDE_CONFIG_DIR`).
- **`src/hooks/session-context.ts`** — times each API call, writes the metric line. Refactored `main()` **132 → 55 lines** by extracting pure helpers (`fetchContext`, `composeContext`, `runMetricInput`, `errorMetricInput`, `resolveProject`, `timeCall`).
- **`scripts/wave-metrics-report.ts`** (new) — `bun scripts/wave-metrics-report.ts` prints emission rate, token percentiles, content-type breakdown, latency percentiles.
- Version bump **2.12.0 → 2.13.0** + CHANGELOG.

## Fail-open contract (preserved)

Telemetry must never block or break a session. `appendMetric` is try/catch-swallowed; `buildMetricRecord` is pure; the write is **synchronous** (`appendFileSync`) — correct, because `process.exit(0)` would drop an async write. Metrics resolution happens outside the `try` but both calls (`metricsEnabled`, `resolveMetricsPath`) are non-throwing.

## Test plan

- [x] `bun test src/hooks/` → **25 pass / 0 fail** (+4 new `composeContext` tests pinning the "full mode must never inject empty-state" invariant; +11 `metrics-logger` tests incl. fail-open on unwritable path)
- [x] `bunx tsc --noEmit` → no new errors (only the pre-existing `mcp-server.ts` one)
- [x] Live dry-run: hook emits pointer, writes metric line, exits 0. Real data: `emitted=true`, 213 chars ≈ 54 tokens, `resume_ms=330`, **`cross_ok=false` `cross_ms=1503`** (cross-project already flagged hitting its 1.5s cap — exactly the signal the gate needs)

## After merge

Tag `v2.13.0` + GitHub release → `/plugin` update in Claude Code to activate → soak ~2 weeks → `wave-metrics-report.ts` → Wave B go/no-go decision.