### PR TITLE
feat(hooks): nudge /forward on compact SessionStart (Wave C, #79)

### DIFF
--- a/src/hooks/__tests__/session-context.test.ts
+++ b/src/hooks/__tests__/session-context.test.ts
@@ -11,9 +11,13 @@
 import { describe, test, expect } from "bun:test";
 import {
   ageInDays,
+  buildForwardNudge,
   buildPointer,
   composeContext,
+  FORWARD_NUDGE,
+  isHandoffStaleOrMissing,
   resolveSessionContextConfig,
+  resolveWaveCEnabled,
   type CrossProjectLite,
 } from "../session-context";
 import type { ResumeResponse } from "../../mcp/handlers/session-handlers";
@@ -151,6 +155,111 @@ describe("buildPointer", () => {
       },
     });
     expect(buildPointer("p", data, null, NOW, 30)).toContain("3 open loops");
+  });
+});
+
+describe("isHandoffStaleOrMissing", () => {
+  test("no handoff → stale (nothing covers 'worth preserving')", () => {
+    expect(isHandoffStaleOrMissing(resume({ empty: true }), NOW, 30)).toBe(
+      true,
+    );
+    expect(isHandoffStaleOrMissing(null, NOW, 30)).toBe(true);
+  });
+
+  test("handoff older than maxAgeDays → stale", () => {
+    const data = resume({
+      latest_handoff: {
+        id: 7,
+        project: "memforge",
+        next_steps: ["x"],
+        created_at: "2026-05-01T12:00:00Z", // ~84d old
+      },
+    });
+    expect(isHandoffStaleOrMissing(data, NOW, 30)).toBe(true);
+  });
+
+  test("fresh handoff → not stale", () => {
+    const data = resume({
+      latest_handoff: {
+        id: 99,
+        project: "memforge",
+        next_steps: ["a"],
+        created_at: "2026-07-22T12:00:00Z", // 2d old
+      },
+    });
+    expect(isHandoffStaleOrMissing(data, NOW, 30)).toBe(false);
+  });
+});
+
+describe("buildForwardNudge (Wave C #79)", () => {
+  test("source=compact + no handoff → nudge present", () => {
+    const out = buildForwardNudge(
+      "compact",
+      resume({ empty: true }),
+      NOW,
+      30,
+      true,
+    );
+    expect(out).toBe(FORWARD_NUDGE);
+    expect(out).toContain("/forward");
+  });
+
+  test("source=compact + stale handoff → nudge present", () => {
+    const data = resume({
+      latest_handoff: {
+        id: 7,
+        project: "memforge",
+        next_steps: ["x"],
+        created_at: "2026-05-01T12:00:00Z", // ~84d old
+      },
+    });
+    const out = buildForwardNudge("compact", data, NOW, 30, true);
+    expect(out).toBe(FORWARD_NUDGE);
+  });
+
+  test("source=compact + fresh handoff → no nudge (already covered)", () => {
+    const data = resume({
+      latest_handoff: {
+        id: 99,
+        project: "memforge",
+        next_steps: ["a"],
+        created_at: "2026-07-22T12:00:00Z", // 2d old
+      },
+    });
+    expect(buildForwardNudge("compact", data, NOW, 30, true)).toBe("");
+  });
+
+  test("source=startup → no nudge, even with no handoff", () => {
+    expect(
+      buildForwardNudge("startup", resume({ empty: true }), NOW, 30, true),
+    ).toBe("");
+  });
+
+  test("source=clear / resume → no nudge (v1 scope is compact only)", () => {
+    expect(
+      buildForwardNudge("clear", resume({ empty: true }), NOW, 30, true),
+    ).toBe("");
+    expect(
+      buildForwardNudge("resume", resume({ empty: true }), NOW, 30, true),
+    ).toBe("");
+  });
+
+  test("waveCEnabled=false → no nudge regardless of source/staleness", () => {
+    expect(
+      buildForwardNudge("compact", resume({ empty: true }), NOW, 30, false),
+    ).toBe("");
+  });
+});
+
+describe("resolveWaveCEnabled", () => {
+  test("defaults to true when config is null or field is absent", () => {
+    expect(resolveWaveCEnabled(null)).toBe(true);
+    expect(resolveWaveCEnabled({})).toBe(true);
+  });
+
+  test("false only when explicitly set false", () => {
+    expect(resolveWaveCEnabled({ waveCEnabled: false })).toBe(false);
+    expect(resolveWaveCEnabled({ waveCEnabled: true })).toBe(true);
   });
 });
 

--- a/src/hooks/metrics-logger.ts
+++ b/src/hooks/metrics-logger.ts
@@ -10,6 +10,9 @@
  * types fired (handoff / cross-project = the non-redundant-vs-claude-mem layer),
  * and fetch latency (validates the 2.5s/1.5s timeout budget).
  *
+ * Wave C (#79) adds `nudge_emitted`: whether the "/forward" nudge fired on a
+ * compact SessionStart — same JSONL line, no separate log file.
+ *
  * Contract: FAIL-OPEN, identical to the hook itself. Nothing here may throw,
  * block, or break a session — a telemetry failure is silently swallowed.
  * Kill switch: MEMFORGE_METRICS=0. Path override: MEMFORGE_METRICS_FILE.
@@ -37,6 +40,7 @@ export interface MetricRecord {
   resume_ms: number;
   cross_ms: number;
   total_ms: number;
+  nudge_emitted: boolean;
   error?: string;
 }
 
@@ -56,6 +60,7 @@ export interface MetricInput {
   resumeMs: number;
   crossMs: number;
   totalMs: number;
+  nudgeEmitted?: boolean; // Wave C (#79) — default false when omitted (error path)
   error?: string;
 }
 
@@ -79,6 +84,7 @@ export function buildMetricRecord(input: MetricInput): MetricRecord {
     resume_ms: input.resumeMs,
     cross_ms: input.crossMs,
     total_ms: input.totalMs,
+    nudge_emitted: input.nudgeEmitted ?? false,
   };
   if (input.error) rec.error = input.error.slice(0, 200);
   return rec;

--- a/src/hooks/session-context.ts
+++ b/src/hooks/session-context.ts
@@ -16,6 +16,19 @@
  *    (the enrichment layer), never plain recent observations (claude-mem owns those).
  *  - process.exit(0) is explicit: an abandoned fetch keeps Bun's event loop alive
  *    up to the request timeout, so we must not rely on natural exit.
+ *
+ * Wave C (#79) — "/forward" nudge on compact:
+ *  - A handoff's value is its LLM-written next_steps/open_loops summary; a shell
+ *    hook has no LLM, so instead of auto-writing a handoff we NUDGE the in-session
+ *    model to run `/forward` itself (model-driven, produces the real summary).
+ *  - Reuses this SAME SessionStart channel (source === "compact") — the proven
+ *    additionalContext path Wave A already uses — rather than PreCompact, whose
+ *    injection is unconfirmed and can block compaction.
+ *  - v1 scope is compact events only. Session end WITHOUT a compact (e.g. the
+ *    user just closes the terminal) is a known gap, deferred — SessionStart has
+ *    no hook for "session is about to end" outside of compaction/clear/startup.
+ *  - Suppressed when a fresh handoff already exists (nothing new to preserve)
+ *    and gated by the `waveCEnabled` kill switch (default true).
  */
 
 import { basename } from "path";
@@ -132,6 +145,48 @@ export function buildPointer(
   );
 }
 
+/** The nudge text injected when a compact just happened and nothing fresh covers it. */
+export const FORWARD_NUDGE =
+  '💾 This session was compacted. If you made progress worth preserving, run **/forward** to persist next-steps & open-loops for the next session.';
+
+/** True when the latest handoff is missing or older than `maxAgeDays` (worth nudging). */
+export function isHandoffStaleOrMissing(
+  resume: ResumeResponse | null,
+  now: number,
+  maxAgeDays: number,
+): boolean {
+  const handoff = resume && !resume.empty ? resume.latest_handoff : null;
+  if (!handoff) return true;
+  const age = ageInDays(handoff.created_at, now);
+  const fresh = age === null || age <= maxAgeDays;
+  return !fresh;
+}
+
+/**
+ * Wave C (#79): build the "/forward" nudge, or "" when it should not fire.
+ * Gated on: source === "compact" (v1 scope — see file header), the kill switch,
+ * and staleness (a fresh handoff already covers "worth preserving").
+ */
+export function buildForwardNudge(
+  source: string,
+  resume: ResumeResponse | null,
+  now: number,
+  maxAgeDays: number,
+  waveCEnabled: boolean,
+): string {
+  if (!waveCEnabled) return "";
+  if (source !== "compact") return "";
+  if (!isHandoffStaleOrMissing(resume, now, maxAgeDays)) return "";
+  return FORWARD_NUDGE;
+}
+
+/** Resolve the Wave C kill switch from plugin config (default true). */
+export function resolveWaveCEnabled(
+  config: { waveCEnabled?: boolean } | null,
+): boolean {
+  return config?.waveCEnabled !== false;
+}
+
 // ---------------------------------------------------------------------------
 // I/O shell (validated by offline dry-run, not unit-tested)
 // ---------------------------------------------------------------------------
@@ -233,6 +288,7 @@ function runMetricInput(
   additionalContext: string,
   { resume, cross, timings }: FetchResult,
   now: number,
+  nudgeEmitted: boolean,
 ): MetricInput {
   const handoff = resume && !resume.empty ? resume.latest_handoff : null;
   return {
@@ -245,6 +301,7 @@ function runMetricInput(
     openLoops: resume?.open_loops?.length || handoff?.open_loops?.length || 0,
     nextSteps: handoff?.next_steps?.length ?? 0,
     hasCrossProject: (cross?.suggestions?.length ?? 0) > 0,
+    nudgeEmitted,
     ...timings,
   };
 }
@@ -290,27 +347,43 @@ export function composeContext(
   return pointer ? `${pointer}\n\n${detail}` : detail;
 }
 
+/** Project name + SessionStart trigger source, resolved from a single stdin drain. */
+interface SessionInput {
+  project: string;
+  source: string;
+}
+
 /**
- * Resolve the project name: MEMFORGE_PROJECT wins, else the basename of the
- * hook payload's cwd, else process.cwd(). Always drains stdin; never throws.
+ * Resolve the project name (MEMFORGE_PROJECT wins, else basename of the hook
+ * payload's cwd, else process.cwd()) and the SessionStart `source` field
+ * ("startup" | "clear" | "compact" | "resume", defaults to "startup" when
+ * missing/unparseable — matches the hooks.json default matcher). Stdin can
+ * only be read once, so project + source are resolved together. Always
+ * drains stdin; never throws.
  */
-async function resolveProject(): Promise<string> {
+async function resolveSessionInput(): Promise<SessionInput> {
   const preset = process.env.MEMFORGE_PROJECT || "";
   try {
     const raw = await readStdin();
-    if (preset) return preset;
-    const input = raw ? (JSON.parse(raw) as { cwd?: unknown }) : {};
+    const input = raw
+      ? (JSON.parse(raw) as { cwd?: unknown; source?: unknown })
+      : {};
     const cwd = typeof input.cwd === "string" ? input.cwd : process.cwd();
-    return basename(cwd);
+    const source = typeof input.source === "string" ? input.source : "startup";
+    return { project: preset || basename(cwd), source };
   } catch {
-    return preset || basename(process.cwd());
+    return { project: preset || basename(process.cwd()), source: "startup" };
   }
 }
 
 async function main(): Promise<void> {
-  const project = await resolveProject();
+  const { project, source } = await resolveSessionInput();
   const cfg = resolveSessionContextConfig(process.env);
   if (!cfg.enabled) emitAndExit("");
+
+  // Wave C (#79) kill switch — resolved alongside cfg, outside the try, same
+  // pattern as resolveSessionContextConfig (getPluginConfig() fails open to null).
+  const waveCEnabled = resolveWaveCEnabled(getPluginConfig());
 
   // Wave B gate telemetry (fail-open, kill switch MEMFORGE_METRICS=0). Resolved
   // up front so both the success and catch paths can log a single JSONL line.
@@ -330,17 +403,27 @@ async function main(): Promise<void> {
       now,
       cfg.maxAgeDays,
     );
-    const additionalContext = composeContext(
-      project,
-      cfg.mode,
-      pointer,
+    const composed = composeContext(project, cfg.mode, pointer, result.resume);
+    const nudge = buildForwardNudge(
+      source,
       result.resume,
+      now,
+      cfg.maxAgeDays,
+      waveCEnabled,
     );
+    const additionalContext = [composed, nudge].filter(Boolean).join("\n\n");
 
     if (collectMetrics) {
       appendMetric(
         buildMetricRecord(
-          runMetricInput(project, cfg.mode, additionalContext, result, now),
+          runMetricInput(
+            project,
+            cfg.mode,
+            additionalContext,
+            result,
+            now,
+            !!nudge,
+          ),
         ),
         metricsPath,
       );

--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -50,6 +50,7 @@ interface PluginConfig {
   promptContextEnabled?: boolean; // Wave B UserPromptSubmit RAG hook (default: false)
   promptRelevanceThreshold?: number; // min score to inject (Wave B)
   promptContextTimeoutMs?: number; // per-prompt search timeout (Wave B)
+  waveCEnabled?: boolean; // Wave C "/forward" nudge on compact (default: true)
 }
 
 /**


### PR DESCRIPTION
Closes #79.

Re-scoped from the original "auto-capture handoff at PreCompact" after design: a handoff's value is its **LLM-written** next_steps/open_loops, and a shell hook has no LLM. So instead of auto-writing a weak handoff, Wave C **nudges the in-session model to run `/forward` itself** — the model has full context + an LLM, so it produces the real summary. This is the "nudge" option chosen over server-side LLM auto-summary and deterministic-checkpoint alternatives.

## How it works
- Reuses **Wave A's proven SessionStart `additionalContext` channel**, gated on `source === "compact"` — *not* PreCompact, whose model-visible injection is unconfirmed and which can block compaction (verified against the Claude Code hooks docs).
- The nudge is appended after Wave A's pointer only when: `waveCEnabled` (kill switch, default true) **and** `source === "compact"` **and** the latest handoff is stale/missing (a fresh handoff already covers "worth preserving").
- **Fail-open preserved** — nothing new can throw or block a session.
- **Telemetry**: `nudge_emitted` added to the existing metrics JSONL line (no new file), so the Wave B-style gate metric — did the nudge actually get followed by a `mem_handoff`? — is measurable by joining hook metrics with the MCP audit log.

## Scope
- **v1: compact events only.** Session-end-*without*-compact (user just closes the terminal) is a documented deferred gap — SessionStart has no "about to end" trigger outside compaction/clear/startup.
- No version bump / CHANGELOG here — that's the release step after merge (3 version files bump together).

## Test plan
- [x] `bun test src/hooks/__tests__/session-context.test.ts` — 25 pass (new: compact+stale→nudge, compact+fresh→none, non-compact→none, kill-switch→none)
- [x] Full suite: 174 pass, 0 fail
- [ ] Manual: trigger `/compact` in a real session with stale handoff → nudge appears; with fresh handoff → suppressed
- [ ] Soak: confirm `nudge_emitted` telemetry + follow-through rate before deciding whether the nudge is effective enough or needs the server-LLM fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)